### PR TITLE
Make focus area on home page link to filtered campaigns

### DIFF
--- a/cypress/e2e/home.test.js
+++ b/cypress/e2e/home.test.js
@@ -30,6 +30,22 @@ describe("Homepage", () => {
           cy.get($el).find("div").should("have.text", $el[0].textContent)
         })
     })
+
+    it("navigates to the campaign list with the focus area as filter applied", () => {
+      cy.get("[data-cy=focus-area-section]")
+        .find("[data-cy=focus-area]")
+        .contains("Weather")
+        .click()
+
+      cy.url().should("include", "/explore/campaigns")
+
+      cy.get("main")
+        .find("[data-cy=filter-chip]")
+        .should("have.length", 1)
+        .and("have.text", "focus: Weather")
+
+      cy.get("main").find("[data-cy=explore-card]").should("have.length", 7)
+    })
   })
 
   describe("region types", () => {

--- a/src/components/home/focus-area-gallery.js
+++ b/src/components/home/focus-area-gallery.js
@@ -1,0 +1,84 @@
+import React from "react"
+import PropTypes from "prop-types"
+import { Link } from "gatsby"
+
+import {
+  AtmosphericCompositionIcon,
+  AtmosphericDynamicsIcon,
+  CarbonCycleEcosystemsIcon,
+  ClimateVariabilityChangeIcon,
+  EarthSurfaceInteriorIcon,
+  GlobalWaterEnergyCycleIcon,
+  WeatherIcon,
+} from "../icons"
+import theme from "../../utils/theme"
+
+const FocusArea = ({ id, caption }) => {
+  // TODO: This mapping is currently done by shortname, as I don't trust
+  // the id yet to be stable.
+  const icons = {
+    "Atmospheric Composition": (
+      <AtmosphericCompositionIcon color={theme.type.base.color} />
+    ),
+    "Atmospheric Dynamics": (
+      <AtmosphericDynamicsIcon color={theme.type.base.color} />
+    ),
+    "Carbon Cycle & Ecosystems": (
+      <CarbonCycleEcosystemsIcon color={theme.type.base.color} />
+    ),
+    "Climate Variability & Change": (
+      <ClimateVariabilityChangeIcon color={theme.type.base.color} />
+    ),
+    "Earth Surface & Interior": (
+      <EarthSurfaceInteriorIcon color={theme.type.base.color} />
+    ),
+    "Global Water & Energy Cycle": (
+      <GlobalWaterEnergyCycleIcon color={theme.type.base.color} />
+    ),
+    Weather: <WeatherIcon color={theme.type.base.color} />,
+  }
+
+  if (!icons[caption]) return null
+
+  return (
+    <Link
+      to="/explore/campaigns"
+      state={{ selectedFocusId: id }} // Pass state as props to the linked page
+      style={{ textAlign: `center` }}
+      data-cy="focus-area"
+    >
+      {icons[caption]}
+      <div>{caption}</div>
+    </Link>
+  )
+}
+
+FocusArea.propTypes = {
+  id: PropTypes.string.isRequired,
+  caption: PropTypes.string.isRequired,
+}
+
+export const FocusAreaGallery = ({ focusAreas }) => {
+  return (
+    <div
+      style={{
+        display: `grid`,
+        gridTemplateColumns: `repeat(auto-fill, minmax(min(120px, 100%), 1fr))`,
+        gap: `1rem`,
+      }}
+    >
+      {focusAreas.map(focus => (
+        <FocusArea key={focus.id} id={focus.id} caption={focus.shortname} />
+      ))}
+    </div>
+  )
+}
+
+FocusAreaGallery.propTypes = {
+  focusAreas: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      shortname: PropTypes.string,
+    })
+  ),
+}

--- a/src/pages/explore/campaigns.js
+++ b/src/pages/explore/campaigns.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react"
+import React, { useState, useRef, useEffect } from "react"
 import PropTypes from "prop-types"
 import { graphql, Link } from "gatsby"
 import Spinner from "react-spinkit"
@@ -11,13 +11,21 @@ import Searchbar from "../../components/searchbar"
 import ExploreSection from "../../components/explore-section"
 import CampaignCard from "../../components/campaign-card"
 
-const Campaigns = ({ data }) => {
+const Campaigns = ({ data, location }) => {
   const { focus, season } = data
+  const { selectedFocusId } = location.state || {}
 
   const [isLoading, setLoading] = useState(false)
   const [sortOrder, toggleSortOrder] = useState("asc")
   const [selectedFilterIds, setFilter] = useState([])
   const [searchResult, setSearchResult] = useState()
+
+  useEffect(() => {
+    if (selectedFocusId) setFilter([selectedFocusId]) // applying only this one selection as filter
+    return () => {
+      // cleanup
+    }
+  }, [selectedFocusId])
 
   const addFilter = id => setFilter([...selectedFilterIds, id])
   const removeFilter = id => setFilter(selectedFilterIds.filter(f => f !== id))
@@ -187,6 +195,11 @@ Campaigns.propTypes = {
       ).isRequired,
     }).isRequired,
   }).isRequired,
+  location: PropTypes.shape({
+    state: PropTypes.shape({
+      selectedFocusId: PropTypes.string,
+    }),
+  }),
 }
 
 export default Campaigns

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -6,13 +6,6 @@ import Layout from "../components/layout"
 import SEO from "../components/seo"
 import Image from "../components/image"
 import {
-  AtmosphericCompositionIcon,
-  AtmosphericDynamicsIcon,
-  CarbonCycleEcosystemsIcon,
-  ClimateVariabilityChangeIcon,
-  EarthSurfaceInteriorIcon,
-  GlobalWaterEnergyCycleIcon,
-  WeatherIcon,
   AirborneInsitu,
   GroundInstruments,
   AirborneRemoteSensors,
@@ -20,6 +13,7 @@ import {
   OceanInstruments,
   FacilityInstruments,
 } from "../components/icons"
+import { FocusAreaGallery } from "../components/home/focus-area-gallery"
 import { RegionCarousel } from "../components/home/region-carousel"
 
 const SectionHeader = ({ tagline, headline }) => (
@@ -32,34 +26,6 @@ const SectionHeader = ({ tagline, headline }) => (
 SectionHeader.propTypes = {
   tagline: PropTypes.string.isRequired,
   headline: PropTypes.string.isRequired,
-}
-
-const FocusArea = ({ id, caption }) => {
-  // TODO: This mapping is currently done by shortname, as I don't trust
-  // the id yet to be stable.
-  const icons = {
-    "Atmospheric Composition": <AtmosphericCompositionIcon />,
-    "Atmospheric Dynamics": <AtmosphericDynamicsIcon />,
-    "Carbon Cycle & Ecosystems": <CarbonCycleEcosystemsIcon />,
-    "Climate Variability & Change": <ClimateVariabilityChangeIcon />,
-    "Earth Surface & Interior": <EarthSurfaceInteriorIcon />,
-    "Global Water & Energy Cycle": <GlobalWaterEnergyCycleIcon />,
-    Weather: <WeatherIcon />,
-  }
-
-  if (!icons[id]) return null
-
-  return (
-    <div style={{ textAlign: `center` }} data-cy="focus-area">
-      {icons[id]}
-      <div>{caption}</div>
-    </div>
-  )
-}
-
-FocusArea.propTypes = {
-  id: PropTypes.string.isRequired,
-  caption: PropTypes.string.isRequired,
 }
 
 const Instrument = ({ id, caption }) => {
@@ -126,21 +92,7 @@ const IndexPage = ({ data }) => {
           tagline="explore nasa earth science"
           headline="Focus Areas"
         />
-        <div
-          style={{
-            display: `grid`,
-            gridTemplateColumns: `repeat(auto-fill, minmax(min(120px, 100%), 1fr))`,
-            gap: `1rem`,
-          }}
-        >
-          {data.allFocusArea.nodes.map(focus => (
-            <FocusArea
-              key={focus.id}
-              id={focus.shortname}
-              caption={focus.shortname}
-            />
-          ))}
-        </div>
+        <FocusAreaGallery focusAreas={data.allFocusArea.nodes} />
       </section>
 
       <section style={styles.section} data-cy="region-type-section">


### PR DESCRIPTION
When clicking on a focus area in the home page, it navigates to the campaign list with the selected focus area as filter applied.

Notable learning: The Gatsby Link API provides a convenient way to [Pass state as props to the linked page](https://www.gatsbyjs.org/docs/gatsby-link/#pass-state-as-props-to-the-linked-page). 