### PR TITLE
Add eslint plugin to use inclusive words

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,7 @@ module.exports = {
     node: true,
     es6: true,
   },
-  plugins: ["react", "react-hooks"],
+  plugins: ["react", "react-hooks", "inclusive-language"],
   parserOptions: {
     ecmaFeatures: {
       jsx: true,
@@ -25,7 +25,9 @@ module.exports = {
     ecmaVersion: 2018, // Allows for the parsing of modern ECMAScript features
     sourceType: "module", // Allows for the use of imports
   },
-  rules: {},
+  rules: {
+    "inclusive-language/use-inclusive-words": "error",
+  },
   overrides: [
     {
       files: ["**/cypress/**"],

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint-config-prettier": "^6.11.0",
     "eslint-config-react-app": "^5.2.1",
     "eslint-plugin-cypress": "^2.10.3",
+    "eslint-plugin-inclusive-language": "^1.0.0",
     "eslint-plugin-jest": "^23.8.2",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-react": "^7.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7001,6 +7001,11 @@ eslint-plugin-import@^2.20.2:
     read-pkg-up "^2.0.0"
     resolve "^1.12.0"
 
+eslint-plugin-inclusive-language@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-inclusive-language/-/eslint-plugin-inclusive-language-1.0.0.tgz#bf2222355065b344770be052a0fc3420a5bba7e5"
+  integrity sha512-O+dHXecD09zB4yaiFXy36KMm2Wt7bHskXF4LMJJLt3j+1956wZ68mH16h50PWwjiLZXcMtrAyBB9N9Vk9Gt84A==
+
 eslint-plugin-jest@^23.8.2:
   version "23.8.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.8.2.tgz#6f28b41c67ef635f803ebd9e168f6b73858eb8d4"


### PR DESCRIPTION
The plugin is quite new and the list of words still short: https://github.com/muenzpraeger/eslint-plugin-inclusive-language/blob/primary/lib/config/inclusive-words.json
I'd suspect it will grow soon, helping us maintain inclusive language in the repository.