### PR TITLE
Add images to region type carousel

### DIFF
--- a/src/components/home/region-carousel.js
+++ b/src/components/home/region-carousel.js
@@ -117,7 +117,7 @@ export const RegionCarousel = ({ regions }) => {
             <CarouselImage
               to="/explore/campaigns"
               state={{ selectedFilterId: region.id }}
-              url={images[region.shortname] && images[region.shortname].url}
+              url={images[region.shortname].url}
               data-cy="region-type"
             >
               <div
@@ -131,9 +131,7 @@ export const RegionCarousel = ({ regions }) => {
                 {region.shortname}
               </div>
             </CarouselImage>
-            <span>
-              {images[region.shortname] && images[region.shortname].description}
-            </span>
+            <span>{images[region.shortname].description}</span>
           </React.Fragment>
         ))}
       </Carousel>

--- a/src/content/images.json
+++ b/src/content/images.json
@@ -39,7 +39,7 @@
     "url": "https://eoimages.gsfc.nasa.gov/images/imagerecords/83000/83828/ISS039-E-018538_lrg.jpg",
     "description": "The narrow island of Manhattan, located between the Hudson River and the East River."
   },
-  "agriculture": {
+  "agricultural": {
     "uuid": "a95c9bd6-395a-409c-8875-586dbc0601f7",
     "url": "https://eoimages.gsfc.nasa.gov/images/imagerecords/5000/5772/kansas_AST_2001175_lrg.jpg",
     "description": "Variegated green crop circles cover what was once shortgrass prairie in southwestern Kansas."


### PR DESCRIPTION
Towards the effort of removing more placeholder items and adding real content, this is inserting images [provided by ADMG](https://docs.google.com/document/d/1WJnVEQ8TlS2MQtfsgBJBZ3bEBLM4CYXHr3eHoAq83to/edit#heading=h.2si7n9hik1ff). I thinking that in the future the .json file is going to be unnecessary and the image url and descriptions added to the api response.

At some point I would like to learn more about Gatsby's image tools and how to apply them to remote images - maybe using [gatsby-plugin-remote-images](https://www.gatsbyjs.org/packages/gatsby-plugin-remote-images/)? Let me know if you come across good resources.