### PR TITLE
Update free text search to find platforms and instruments

### DIFF
--- a/src/pages/explore/campaigns.js
+++ b/src/pages/explore/campaigns.js
@@ -47,7 +47,7 @@ const Campaigns = ({ data, location }) => {
     setLoading(true)
     e.preventDefault()
     let searchstring = inputElement.current.value
-    const result = await api.fetchSearchResult(searchstring)
+    const result = await api.fetchSearchResult("campaign", searchstring)
     setSearchResult(result)
     setLoading(false)
   }

--- a/src/pages/explore/instruments.js
+++ b/src/pages/explore/instruments.js
@@ -41,7 +41,7 @@ export default function Instruments({ data, location }) {
     setLoading(true)
     e.preventDefault()
     let searchstring = inputElement.current.value
-    const result = await api.fetchSearchResult(searchstring)
+    const result = await api.fetchSearchResult("instrument", searchstring)
     setSearchResult(result)
     setLoading(false)
   }

--- a/src/pages/explore/platforms.js
+++ b/src/pages/explore/platforms.js
@@ -41,7 +41,7 @@ const Platforms = ({ data, location }) => {
     setLoading(true)
     e.preventDefault()
     let searchstring = inputElement.current.value
-    const result = await api.fetchSearchResult(searchstring)
+    const result = await api.fetchSearchResult("platform", searchstring)
     setSearchResult(result)
     setLoading(false)
   }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,10 +1,10 @@
 const fetch = require("node-fetch")
 
 export default {
-  async fetchSearchResult(searchstring) {
+  async fetchSearchResult(type, searchstring) {
     try {
       const response = await fetch(
-        `http://ec2-3-85-33-46.compute-1.amazonaws.com/api/campaign?search=${searchstring}`,
+        `http://ec2-3-85-33-46.compute-1.amazonaws.com/api/${type}?search=${searchstring}`,
         {
           method: "GET",
         }


### PR DESCRIPTION
...to direct the api request to the corresponding search endpoint `/platform` or `/instrument`, respectively.

The endpoint implementation allows to provide a `search_fields` parameter, that we could use to specify what fields to run the search on (e.g. `search_fields=short_name,long_name`). If the `search_fields` parameter is not provided, the endpoints currently returns a search on these default fields:
```
campaign: short_name, long_name,description_short, focus_phenomena 
platform: short_name,long_name,description
instrument: short_name, long_name
```