### PR TITLE
Changes DOI lang to mention campaign

### DIFF
--- a/cypress/e2e/campaign.test.js
+++ b/cypress/e2e/campaign.test.js
@@ -114,7 +114,7 @@ describe("Campaign", () => {
       cy.get("[data-cy=link-list]")
         .find("[data-cy=doi-link]")
         .should("exist")
-        .and("have.text", "Campaign DOI: not available")
+        .and("have.text", "no campaign DOI available")
     })
   })
 

--- a/src/templates/campaign/overview-section.js
+++ b/src/templates/campaign/overview-section.js
@@ -89,10 +89,10 @@ const OverviewSection = ({
                 textOverflow: `ellipsis`,
               }}
             >
-              Campaign DOI: <ExternalLink label={doi} url={doi} id="doi" />
+              DOI: <ExternalLink label={doi} url={doi} id="doi" />
             </p>
           ) : (
-            <p data-cy="doi-link">Campaign DOI: not available</p>
+            <p data-cy="doi-link">no campaign DOI available</p>
           )}
         </li>
         {projectWebsite && (


### PR DESCRIPTION
I thought it would be less redundant to do: `Campaign DOI: ...` instead of `DOI: no Campaign DOI available` does that makes sense?