### PR TITLE
Add script to deploy from ./public to surge

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   "license": "MIT",
   "scripts": {
     "build": "gatsby build",
+    "deploy": "surge --project ./public --domain airborne-inventory.surge.sh",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "lint": "eslint --ignore-path .gitignore \"**/*.{js,jsx}\"",


### PR DESCRIPTION
@necoline , I added you to the surge project via `surge --add necoline@developmentseed.org` 
Can you see if this would allow you to deploy from your machine?

These are the steps:
1. Add a valid ADMG_ACCESS_TOKEN to `.env.production`
2. Run `yarn build` on the branch you want to have deployed (likely develop)
Optional: Run `yarn serve` to see if the build looks good on http://localhost:9000/
3. Run `yarn deploy` to get it shipped to surge. Note: You will need to have surge set up on your machine with the above account 

Please let me know if it works 🙂 