### PR TITLE
 More circle ci experiments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           <<: *restore_cache_def
       - run: yarn build
       - save_cache:
-          key: v2-build-{{ .Branch }}
+          key: v1-build-{{ .Branch }}-{{ .Revision }}
           paths:
             - public ## cache build
   test-end-to-end:
@@ -71,7 +71,7 @@ jobs:
             - v1-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - restore_cache:
           keys:
-            - v2-build-{{ .Branch }} # the previously build /public
+            - v1-build-{{ .Branch }}-{{ .Revision }} # the previously build /public
       - run: yarn test:e2e:ci
       - run: yarn test:cov && yarn test:cov:summary
       - store_artifacts:


### PR DESCRIPTION
Removing unnecessary tasks by improving the caching. Contributes to #108 

I am still thinking about how to improve the caching of the build (`/public`). It is now set up to re-build in between different ci runs, which seem to make sense as we do re-run `yarn build` as part of the pipeline.

It is worth mentioning that I added `GATSBY_CPU_COUNT=1` as environment variable to circle ci, this seems to be fixing a frequent issue with ENOMEM ([see here](https://github.com/gatsbyjs/gatsby/issues/24577#issuecomment-670369974) or [here](https://support.circleci.com/hc/en-us/articles/360038192673-NodeJS-Builds-or-Test-Suites-Fail-With-ENOMEM-or-a-Timeout))

A note on cache size, [from the docs](https://circleci.com/docs/2.0/caching/#cache-size):
>We recommend keeping cache sizes under 500MB. This is our upper limit for corruption checks because above this limit check times would be excessively long. You can view the cache size from the CircleCI Jobs page within the restore_cache step. Larger cache sizes are allowed but may cause problems due to a higher chance of decompression issues and corruption during download. To keep cache sizes down, consider splitting into multiple distinct caches.