### PR TITLE
Add a way to manually invalidate circle ci cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 base_def: &base_def
   docker:
     - image: node:12
-  working_directory: ~/.
+  working_directory: ~/app
   environment:
     - DEVELOPMENT_BRANCH: develop
 
@@ -60,7 +60,7 @@ jobs:
     docker:
       # the Docker image with Cypress dependencies
       - image: cypress/base:12
-    working_directory: ~/.
+    working_directory: ~/app
     environment:
       ## this enables colors in the output
       TERM: xterm
@@ -72,6 +72,13 @@ jobs:
       - restore_cache:
           keys:
             - build-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ .Revision }} # the previously build /public
+      # just in case the install script skipped Cypress post-install hook for some reason
+      # call install ourselves. If there is binary already installed, it will quickly finish.
+      # By overriding the install step we make sure the NPM modules AND the Cypress binary
+      # are installed before the cache is saved
+      - run: yarn cypress install
+      # good idea to verify the binary so its status is saved in the cache as well
+      - run: yarn cypress verify
       - run: yarn test:e2e:ci
       - run: yarn test:cov && yarn test:cov:summary
       - store_artifacts:


### PR DESCRIPTION
We were running into an issue, because I made changes to the directory and caching, but circle ci, when running on the branch it knows already (`develop`) gets an old cache that will cause the error.

With this change, we can change the increment in the Environment variable `CACHE_VERSION`, which will cause circle ci to create a new cache. Solution from the docs: https://support.circleci.com/hc/en-us/articles/115015426888-Clear-project-dependency-cache