### PR TITLE
Query for distinct funding agencies and add filter to campaign

### DIFF
--- a/src/components/explore/filter-menu.js
+++ b/src/components/explore/filter-menu.js
@@ -109,6 +109,11 @@ const FilterMenu = ({
                   label="Platform"
                   options={getFilterOptionsById("platform")}
                 />
+                <Filter
+                  id="funding"
+                  label="Funding Agency"
+                  options={getFilterOptionsById("funding")}
+                />
               </>
             )}
             {category === "platforms" && (

--- a/src/pages/__tests__/__snapshots__/selectors.test.js.snap
+++ b/src/pages/__tests__/__snapshots__/selectors.test.js.snap
@@ -625,7 +625,7 @@ exports[`Campaigns page renders correctly 1`] = `
                     alt="CARVE logo"
                     fixed={
                       Object {
-                        "src": "/static/3dec137acafa7ac0c3a74368b2cb56b3/f8771/carve_logo_update.jpg",
+                        "src": "/static/3dec137acafa7ac0c3a74368b2cb56b3/9dd03/carve_logo_update.jpg",
                       }
                     }
                     src="test-image.png"
@@ -733,7 +733,7 @@ exports[`Campaigns page renders correctly 1`] = `
                     alt="DC3 logo"
                     fixed={
                       Object {
-                        "src": "/static/c4b36cb85ef25d65d08739c329b04e52/ad39b/dc3-logo.png",
+                        "src": "/static/c4b36cb85ef25d65d08739c329b04e52/7f3c0/dc3-logo.png",
                       }
                     }
                     src="test-image.png"
@@ -838,7 +838,7 @@ exports[`Campaigns page renders correctly 1`] = `
                     alt="ARCTAS logo"
                     fixed={
                       Object {
-                        "src": "/static/2bd234de67183d020fabe8584d7713ff/f8771/arctas_spring.jpg",
+                        "src": "/static/2bd234de67183d020fabe8584d7713ff/9dd03/arctas_spring.jpg",
                       }
                     }
                     src="test-image.png"

--- a/test/__fixtures__/campaign-query.json
+++ b/test/__fixtures__/campaign-query.json
@@ -9,7 +9,7 @@
           "nasaImg": {
             "childImageSharp": {
               "fixed": {
-                "src": "/static/070840eb6299020cd65fd46e27c54400/ad39b/aces_logo.png"
+                "src": "/static/070840eb6299020cd65fd46e27c54400/7f3c0/aces_logo.png"
               }
             }
           }
@@ -89,108 +89,8 @@
           {
             "id": "7d58f61f-a73a-435a-9c9a-d4389e052aab"
           }
-        ]
-      },
-      {
-        "logo": {
-          "nasaImgAlt": "ARCTAS logo",
-          "nasaImgUrl": "https://cloud1.arc.nasa.gov/arctas/images/arctas_spring.jpg",
-          "nasaImg": {
-            "childImageSharp": {
-              "fixed": {
-                "src": "/static/2bd234de67183d020fabe8584d7713ff/f8771/arctas_spring.jpg"
-              }
-            }
-          }
-        },
-        "ongoing": false,
-        "shortname": "ARCTAS",
-        "longname": "Arctic Research of the Composition of the Troposphere from Aircraft and Satellites",
-        "id": "e48c2d79-822b-4c9e-9f72-2776d5d1eac6",
-        "seasons": [
-          {
-            "id": "7394cb29-fa27-45d0-b4f3-7132b9e5bd52"
-          },
-          {
-            "id": "abde509c-8f19-4f12-af69-ed3d41ba09f9"
-          },
-          {
-            "id": "87a8463c-b2f4-4315-84cc-cb8d20024247"
-          }
         ],
-        "focus": [
-          {
-            "id": "e42c7970-1913-44b4-822b-8d620eef8df8"
-          },
-          {
-            "id": "43bc862a-ece2-427c-ad5f-368466d3bc98"
-          }
-        ],
-        "geophysical": [
-          {
-            "id": "4c19e4b9-b47d-4550-bf1b-fb5daf1fdeb2"
-          },
-          {
-            "id": "e8041eba-37e9-4c38-8f62-5119c7dde4b1"
-          },
-          {
-            "id": "458c5a19-17dd-48c1-bc12-c22ab69afd10"
-          },
-          {
-            "id": "1ffeed03-f578-4e23-8d7a-3fb59ca23321"
-          },
-          {
-            "id": "830fe73e-7102-4b97-bc14-c31d70de1ad3"
-          }
-        ],
-        "startdate": "2008-04-01",
-        "enddate": "2008-07-14",
-        "region": "Alaska, Western Canada, California",
-        "deployments": [
-          {
-            "id": "e71e8fbd-9f1a-4b91-9187-4b71109c25ff",
-            "regions": [
-              {
-                "id": "eb28c912-b2eb-41fe-9469-a24a3a096357",
-                "shortname": "continental"
-              }
-            ]
-          },
-          {
-            "id": "2de3c9cf-bff5-4d87-ab03-2b9690ec10c8",
-            "regions": [
-              {
-                "id": "eb28c912-b2eb-41fe-9469-a24a3a096357",
-                "shortname": "continental"
-              }
-            ]
-          },
-          {
-            "id": "683bfce3-f70e-49fa-8f87-74151327db19",
-            "regions": [
-              {
-                "id": "eb28c912-b2eb-41fe-9469-a24a3a096357",
-                "shortname": "continental"
-              }
-            ]
-          }
-        ],
-        "countCollectionPeriods": 0,
-        "countDataProducts": 0,
-        "platforms": [
-          {
-            "id": "715351b2-1126-4c0d-8130-5caa9f044f6d"
-          },
-          {
-            "id": "a0dea5de-aa33-4f13-a8a4-34729e3de5fd"
-          },
-          {
-            "id": "6fc94f62-d4f2-4a08-9511-2234d91b0665"
-          },
-          {
-            "id": "7d58f61f-a73a-435a-9c9a-d4389e052aab"
-          }
-        ]
+        "fundingAgency": "NASA"
       },
       {
         "logo": {
@@ -199,7 +99,7 @@
           "nasaImg": {
             "childImageSharp": {
               "fixed": {
-                "src": "/static/6cac19092a1bce4be3f0a8b6e564adb3/ad39b/airmossLogo.png"
+                "src": "/static/6cac19092a1bce4be3f0a8b6e564adb3/7f3c0/airmossLogo.png"
               }
             }
           }
@@ -564,7 +464,8 @@
           {
             "id": "7d58f61f-a73a-435a-9c9a-d4389e052aab"
           }
-        ]
+        ],
+        "fundingAgency": "NASA"
       },
       {
         "logo": {
@@ -573,7 +474,7 @@
           "nasaImg": {
             "childImageSharp": {
               "fixed": {
-                "src": "/static/3dec137acafa7ac0c3a74368b2cb56b3/f8771/carve_logo_update.jpg"
+                "src": "/static/3dec137acafa7ac0c3a74368b2cb56b3/9dd03/carve_logo_update.jpg"
               }
             }
           }
@@ -693,7 +594,8 @@
           {
             "id": "7d58f61f-a73a-435a-9c9a-d4389e052aab"
           }
-        ]
+        ],
+        "fundingAgency": "NASA"
       },
       {
         "logo": {
@@ -702,7 +604,7 @@
           "nasaImg": {
             "childImageSharp": {
               "fixed": {
-                "src": "/static/c4b36cb85ef25d65d08739c329b04e52/ad39b/dc3-logo.png"
+                "src": "/static/c4b36cb85ef25d65d08739c329b04e52/7f3c0/dc3-logo.png"
               }
             }
           }
@@ -792,7 +694,8 @@
           {
             "id": "c94db25b-1b48-47fe-90e3-47e8c16f0a92"
           }
-        ]
+        ],
+        "fundingAgency": "NASA"
       },
       {
         "logo": {
@@ -801,7 +704,7 @@
           "nasaImg": {
             "childImageSharp": {
               "fixed": {
-                "src": "/static/4e1cc27c28411e8c942f140039bb625b/ad39b/gcpexlogo.png"
+                "src": "/static/4e1cc27c28411e8c942f140039bb625b/7f3c0/gcpexlogo.png"
               }
             }
           }
@@ -858,7 +761,8 @@
           {
             "id": "732c68d8-124b-45be-b2d2-dbc2d305d855"
           }
-        ]
+        ],
+        "fundingAgency": "NASA"
       },
       {
         "logo": {
@@ -923,7 +827,8 @@
           {
             "id": "bb761da6-1606-444c-92d1-e6d30954f2d7"
           }
-        ]
+        ],
+        "fundingAgency": "NOAA, NASA"
       },
       {
         "logo": {
@@ -932,7 +837,7 @@
           "nasaImg": {
             "childImageSharp": {
               "fixed": {
-                "src": "/static/2803312240ff21bec233dee65f422031/f8771/464732main_grip_graphic_med.jpg"
+                "src": "/static/2803312240ff21bec233dee65f422031/9dd03/464732main_grip_graphic_med.jpg"
               }
             }
           }
@@ -1001,7 +906,8 @@
           {
             "id": "2cbc931a-6f47-45f0-bff6-659ef2efc68d"
           }
-        ]
+        ],
+        "fundingAgency": "NASA"
       },
       {
         "logo": {
@@ -1010,7 +916,7 @@
           "nasaImg": {
             "childImageSharp": {
               "fixed": {
-                "src": "/static/3d520693bc11c953f22f86f860ffd08a/ad39b/HS3_logo.png"
+                "src": "/static/3d520693bc11c953f22f86f860ffd08a/7f3c0/HS3_logo.png"
               }
             }
           }
@@ -1114,7 +1020,8 @@
           {
             "id": "2cbc931a-6f47-45f0-bff6-659ef2efc68d"
           }
-        ]
+        ],
+        "fundingAgency": "NASA"
       },
       {
         "logo": {
@@ -1123,7 +1030,7 @@
           "nasaImg": {
             "childImageSharp": {
               "fixed": {
-                "src": "/static/6b1df71a80ace65c6ad8ea8294fcaa5f/ad39b/logo_image2.png"
+                "src": "/static/6b1df71a80ace65c6ad8ea8294fcaa5f/7f3c0/logo_image2.png"
               }
             }
           }
@@ -1212,8 +1119,115 @@
           {
             "id": "7d58f61f-a73a-435a-9c9a-d4389e052aab"
           }
-        ]
+        ],
+        "fundingAgency": "NASA"
+      },
+      {
+        "logo": {
+          "nasaImgAlt": "ARCTAS logo",
+          "nasaImgUrl": "https://cloud1.arc.nasa.gov/arctas/images/arctas_spring.jpg",
+          "nasaImg": {
+            "childImageSharp": {
+              "fixed": {
+                "src": "/static/2bd234de67183d020fabe8584d7713ff/9dd03/arctas_spring.jpg"
+              }
+            }
+          }
+        },
+        "ongoing": false,
+        "shortname": "ARCTAS",
+        "longname": "Arctic Research of the Composition of the Troposphere from Aircraft and Satellites",
+        "id": "e48c2d79-822b-4c9e-9f72-2776d5d1eac6",
+        "seasons": [
+          {
+            "id": "7394cb29-fa27-45d0-b4f3-7132b9e5bd52"
+          },
+          {
+            "id": "abde509c-8f19-4f12-af69-ed3d41ba09f9"
+          },
+          {
+            "id": "87a8463c-b2f4-4315-84cc-cb8d20024247"
+          }
+        ],
+        "focus": [
+          {
+            "id": "e42c7970-1913-44b4-822b-8d620eef8df8"
+          },
+          {
+            "id": "43bc862a-ece2-427c-ad5f-368466d3bc98"
+          }
+        ],
+        "geophysical": [
+          {
+            "id": "4c19e4b9-b47d-4550-bf1b-fb5daf1fdeb2"
+          },
+          {
+            "id": "e8041eba-37e9-4c38-8f62-5119c7dde4b1"
+          },
+          {
+            "id": "458c5a19-17dd-48c1-bc12-c22ab69afd10"
+          },
+          {
+            "id": "1ffeed03-f578-4e23-8d7a-3fb59ca23321"
+          },
+          {
+            "id": "830fe73e-7102-4b97-bc14-c31d70de1ad3"
+          }
+        ],
+        "startdate": "2008-04-01",
+        "enddate": "2008-07-14",
+        "region": "Alaska, Western Canada, California",
+        "deployments": [
+          {
+            "id": "e71e8fbd-9f1a-4b91-9187-4b71109c25ff",
+            "regions": [
+              {
+                "id": "eb28c912-b2eb-41fe-9469-a24a3a096357",
+                "shortname": "continental"
+              }
+            ]
+          },
+          {
+            "id": "2de3c9cf-bff5-4d87-ab03-2b9690ec10c8",
+            "regions": [
+              {
+                "id": "eb28c912-b2eb-41fe-9469-a24a3a096357",
+                "shortname": "continental"
+              }
+            ]
+          },
+          {
+            "id": "683bfce3-f70e-49fa-8f87-74151327db19",
+            "regions": [
+              {
+                "id": "eb28c912-b2eb-41fe-9469-a24a3a096357",
+                "shortname": "continental"
+              }
+            ]
+          }
+        ],
+        "countCollectionPeriods": 0,
+        "countDataProducts": 0,
+        "platforms": [
+          {
+            "id": "715351b2-1126-4c0d-8130-5caa9f044f6d"
+          },
+          {
+            "id": "a0dea5de-aa33-4f13-a8a4-34729e3de5fd"
+          },
+          {
+            "id": "6fc94f62-d4f2-4a08-9511-2234d91b0665"
+          },
+          {
+            "id": "7d58f61f-a73a-435a-9c9a-d4389e052aab"
+          }
+        ],
+        "fundingAgency": "NASA"
       }
+    ],
+    "options": [
+      "NASA",
+      "NOAA, NASA"
     ]
   },
   "allSeason": {
@@ -1539,24 +1553,9 @@
   "allPlatform": {
     "options": [
       {
-        "id": "96b56413-2068-4fc4-a093-4780a02744e9",
-        "shortname": "ALAR",
-        "longname": "Airborne Laboratory for Atmospheric Research"
-      },
-      {
-        "id": "c63849f7-ea91-4525-9029-940a9c53ed36",
-        "shortname": "ALTUS II",
-        "longname": "ALTUS II"
-      },
-      {
         "id": "28154c07-d35b-4e13-982c-63b69e1fe57c",
         "shortname": "ASO",
         "longname": "Airborne Snow Observatory"
-      },
-      {
-        "id": "a0dea5de-aa33-4f13-a8a4-34729e3de5fd",
-        "shortname": "B-200",
-        "longname": "Beechcraft King Air B-200"
       },
       {
         "id": "fa7f2693-c9b1-4d89-b14c-0672487dc049",
@@ -1612,6 +1611,21 @@
         "id": "2cbc931a-6f47-45f0-bff6-659ef2efc68d",
         "shortname": "WB-57",
         "longname": "NASA WB-57"
+      },
+      {
+        "id": "96b56413-2068-4fc4-a093-4780a02744e9",
+        "shortname": "ALAR",
+        "longname": "Airborne Laboratory for Atmospheric Research"
+      },
+      {
+        "id": "c63849f7-ea91-4525-9029-940a9c53ed36",
+        "shortname": "ALTUS II",
+        "longname": "ALTUS II"
+      },
+      {
+        "id": "a0dea5de-aa33-4f13-a8a4-34729e3de5fd",
+        "shortname": "B-200",
+        "longname": "Beechcraft King Air B-200"
       },
       {
         "id": "7d58f61f-a73a-435a-9c9a-d4389e052aab",


### PR DESCRIPTION
I was actually hoping to get this done via GraphQL magic, using `createSchemaCustomization`, `schema.buildObjectType` or  `createFieldExtension`... (see [docs](https://www.gatsbyjs.com/docs/schema-customization/))

Unfortunately did not get it to work. Not sure if actually the functionality to extend a type definition isn't implemented (as mentioned in this issue https://github.com/gatsbyjs/gatsby/issues/26301)? I was trying to add a new type FundingAgency and create nodes based on whats in campaign.funding_agency. I actually had it almost working, but instead of two nodes for each distinct funding agency I got a node for each campaign with the campaign.funding_agency... many times the same. Writing this out makes me think I should revisit and apply the splitting/cleaning on node creation instead of after executing the campaigns query...

Hm. Anyways, I think the suggestion in this PR works, but might need some improvements. Let me know your thoughts.