### PR TITLE
Avoid useEffect to fix scroll bug

### DIFF
--- a/src/components/home/region-carousel.js
+++ b/src/components/home/region-carousel.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react"
+import React, { useState, useRef } from "react"
 import PropTypes from "prop-types"
 import { Link } from "gatsby"
 import Image from "gatsby-image"
@@ -30,22 +30,11 @@ const controlButtonLRStyle = {
   fontWeight: `bold`,
   fontSize: `large`,
 }
-let isInitialRender = true
 
 export const RegionCarousel = ({ regions }) => {
-  const element = useRef(null)
+  const controlTextRef = useRef(null)
 
   const [slideIndex, setSlideIndex] = useState(0)
-
-  useEffect(() => {
-    if (element && !isInitialRender)
-      element.current.scrollIntoView({
-        behavior: "smooth",
-        block: "nearest",
-        inline: "nearest",
-      })
-    isInitialRender = false
-  }, [slideIndex])
 
   return (
     <>
@@ -59,7 +48,7 @@ export const RegionCarousel = ({ regions }) => {
         {regions.map((region, index) => (
           <ControlTextButton
             key={region.id}
-            ref={index === slideIndex ? element : null}
+            ref={index === slideIndex ? controlTextRef : null}
             selected={index === slideIndex}
             onClick={() => setSlideIndex(index)}
           >
@@ -70,7 +59,14 @@ export const RegionCarousel = ({ regions }) => {
 
       <Carousel
         slideIndex={slideIndex}
-        afterSlide={slideIndex => setSlideIndex(slideIndex)}
+        afterSlide={slideIndex => {
+          setSlideIndex(slideIndex)
+          controlTextRef.current.scrollIntoView({
+            behavior: "smooth",
+            block: "nearest",
+            inline: "nearest",
+          })
+        }}
         renderBottomCenterControls={null}
         defaultControlsConfig={{
           nextButtonText: `⦊`,


### PR DESCRIPTION
For some reason, useEffect was being executed on every render (except manually excluded initial) even when `slideIndex` did not change. While this is annoying and confusing, I thought it was an easier fix to omit useEffect and plainly, manually scoll the element into view after every slide change. Should have the same effect as intended with useEffect. The only thing I am not sure about is the dependency between setting the state, setting the ref based on the slideIndex from state, and immediately scrolling this ref into view... Is this safe as I am doing in this PR, or do we need to add some extra logic?