### PR TITLE
Adapt static map parameters to better fit bbox

### DIFF
--- a/src/templates/campaign/hero.js
+++ b/src/templates/campaign/hero.js
@@ -36,14 +36,11 @@ const CampaignHero = ({
   const distance = turf.distance(west, east, options)
   const offsetCoords = turf.transformTranslate(
     geometry,
-    distance * 0.5,
+    distance * 0.75,
     -90,
     options
   )
-
-  const scaledCoords = turf.bbox(
-    turf.transformScale(offsetCoords, 1.4, options)
-  )
+  const scaledCoords = turf.bbox(turf.transformScale(offsetCoords, 3, options))
 
   const containerRef = useRef()
   const { width } = useContainerDimensions(containerRef)


### PR DESCRIPTION
This is just a quickfix for the upcoming demo. The static image maps are temporary and are to be replaced with GL JS where we can fitBounds, see #134. 