### PR TITLE
Update count of collection periods

### DIFF
--- a/cypress/e2e/campaign.test.js
+++ b/cypress/e2e/campaign.test.js
@@ -36,7 +36,7 @@ describe("Campaign", () => {
         .should($stat => {
           expect($stat, "3 items").to.have.length(3)
           expect($stat.eq(0), "first item").to.contain("1")
-          expect($stat.eq(1), "second item").to.contain("6")
+          expect($stat.eq(1), "second item").to.contain("58")
           expect($stat.eq(2), "third item").to.contain("9")
         })
     })

--- a/src/templates/campaign/index.js
+++ b/src/templates/campaign/index.js
@@ -102,7 +102,7 @@ const CampaignTemplate = ({ data: { campaign }, path }) => {
         longname={campaign.longname}
         focusListing={campaign.focus.map(x => x.shortname).join(", ")}
         countDeployments={campaign.countDeployments}
-        countCollectionPeriods={collectionPeriods.length}
+        countCollectionPeriods={campaign.countCollectionPeriods}
         countDataProducts={dois.length}
       />
       <InpageNav


### PR DESCRIPTION
To display the value from database, not summed up value, as requested (the backend got updated just minutes ago with the new value). We might want to think about ways to differentiate the calculated numbers from manual entries.