### PR TITLE
Support manual deployments to production

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - production
+  workflow_dispatch:  # Support manual deployments, https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
Similar to #187, we want to be able to trigger production deployments from the maintenance interface.