### PR TITLE
Allow region to not have an image

### DIFF
--- a/src/components/home/region-carousel.js
+++ b/src/components/home/region-carousel.js
@@ -108,7 +108,9 @@ export const RegionCarousel = ({ regions }) => {
               >
                 {region.shortname}
               </div>
-              <span>{region.image ? region.image.nasaImgAlt : "No image available."}</span>
+              <span>
+                {region.image ? region.image.nasaImgAlt : "No image available."}
+              </span>
             </Link>
           </React.Fragment>
         ))}


### PR DESCRIPTION
We have a new region in the inventory where an image was not specified. This was causing the build to fail.

I am making the image optional, adding a alt text to inform about the missing image.