### PR TITLE
Fix typo.

### DIFF
--- a/src/content/nasa-images.json
+++ b/src/content/nasa-images.json
@@ -54,7 +54,7 @@
     "nasaImgAlt": "Variegated green crop circles cover what was once shortgrass prairie in southwestern Kansas. (Photography courtesy NASA/GSFC)"
   },
   {
-    "shortname": "equitorial",
+    "shortname": "equatorial",
     "category": "region",
     "nasaImgUrl": "https://images-assets.nasa.gov/image/sts054-95-042/sts054-95-042~orig.jpg",
     "nasaImgAlt": "Equatorial Wave Line, Pacific Ocean. (Photography courtesy NASA Images)"

--- a/test/__fixtures__/explore-query.json
+++ b/test/__fixtures__/explore-query.json
@@ -3220,7 +3220,7 @@
         },
         {
           "id": "60872c59-285a-4acc-ab11-5700a4251f80",
-          "shortname": "equitorial"
+          "shortname": "equatorial"
         },
         {
           "id": "a11e585d-12ac-4240-a7d5-6b67a7d37f3b",

--- a/test/__fixtures__/home-query.json
+++ b/test/__fixtures__/home-query.json
@@ -383,7 +383,7 @@
         },
         {
           "id": "60872c59-285a-4acc-ab11-5700a4251f80",
-          "shortname": "equitorial",
+          "shortname": "equatorial",
           "example": "Singapore, Indonesia, portions of central Africa",
           "image": {
             "nasaImgUrl": "https://images-assets.nasa.gov/image/sts054-95-042/sts054-95-042~orig.jpg",


### PR DESCRIPTION
There was a small typo. Changed "equitorial" to "equatorial". Hopefully, this will take care of the missing image issue.