### PR TITLE
Move fbm state to context

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -11,7 +11,7 @@ import PropTypes from "prop-types"
 
 import "@fontsource/titillium-web"
 
-import AuthProvider from "./src/components/auth-provider"
+import FBMProvider from "./src/components/fbm-provider"
 
 export const shouldUpdateScroll = ({ routerProps: { location } }) => {
   if (location.hash) {
@@ -22,7 +22,7 @@ export const shouldUpdateScroll = ({ routerProps: { location } }) => {
 }
 
 export const wrapRootElement = ({ element }) => {
-  return <AuthProvider>{element}</AuthProvider>
+  return <FBMProvider>{element}</FBMProvider>
 }
 
 wrapRootElement.propTypes = {

--- a/src/components/fbm-provider.js
+++ b/src/components/fbm-provider.js
@@ -1,0 +1,22 @@
+import React, { createContext, useState } from "react"
+import PropTypes from "prop-types"
+
+export const FBMContext = createContext({ isFBMLoaded: false })
+
+function FBMProvider({ children }) {
+  const [isFBMLoaded, setIsFBMLoaded] = useState(
+    typeof window !== undefined && window.feedback && window.feedback.showForm
+  )
+
+  return (
+    <FBMContext.Provider value={{ isFBMLoaded, setIsFBMLoaded }}>
+      {children}
+    </FBMContext.Provider>
+  )
+}
+
+FBMProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+}
+
+export default FBMProvider

--- a/src/components/inpage-nav.js
+++ b/src/components/inpage-nav.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react"
+import React, { useContext } from "react"
 import PropTypes from "prop-types"
 import { Link } from "gatsby"
 
@@ -6,6 +6,7 @@ import { CaseiLogoIcon } from "../icons"
 import { POSITIVE } from "../utils/constants"
 import { colors, breakpoints } from "../theme"
 import Button from "../components/button"
+import { FBMContext } from "./fbm-provider"
 
 const InpageLink = props => (
   <li
@@ -33,17 +34,7 @@ InpageLink.propTypes = {
 }
 
 const InpageNav = ({ shortname, items }) => {
-  const [isFBMLoaded, setIsFBMLoaded] = useState(false)
-
-  useEffect(() => {
-    //ensure that feedback module is loaded and inititalized (external script)
-    if (window.feedback) {
-      if (!window.feedback.showForm) {
-        window.feedback.init({ showIcon: false })
-      }
-      setIsFBMLoaded(true)
-    }
-  }, [])
+  const { isFBMLoaded } = useContext(FBMContext)
 
   return (
     <div

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -5,7 +5,7 @@
  * See: https://www.gatsbyjs.org/docs/use-static-query/
  */
 
-import React, { useEffect } from "react"
+import React from "react"
 import PropTypes from "prop-types"
 import { useStaticQuery, graphql } from "gatsby"
 import styled from "styled-components"
@@ -39,16 +39,6 @@ const Layout = ({ children, isHeaderFixed }) => {
       }
     }
   `)
-
-  useEffect(() => {
-    // ensure that feedback module is loaded and inititalized
-    // (external script added via Helmet (see seo.js))
-    if (window.feedback) {
-      if (!window.feedback.showForm) {
-        window.feedback.init({ showIcon: false })
-      }
-    }
-  }, [])
 
   return (
     <Container id="top" data-cy="page">

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -5,10 +5,11 @@
  * See: https://www.gatsbyjs.org/docs/use-static-query/
  */
 
-import React from "react"
+import React, { useContext } from "react"
 import PropTypes from "prop-types"
 import { Helmet } from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
+import { FBMContext } from "./fbm-provider"
 
 function SEO({ description, lang, meta, title }) {
   const { site } = useStaticQuery(
@@ -29,6 +30,8 @@ function SEO({ description, lang, meta, title }) {
 
   const FBM_URL = `https://fbm.earthdata.nasa.gov/for/CASEI/feedback.js`
 
+  const { setIsFBMLoaded } = useContext(FBMContext)
+
   const handleChangeClientState = (newState, addedTags) => {
     if (addedTags && addedTags.scriptTags) {
       const foundScript = addedTags.scriptTags.find(
@@ -36,6 +39,7 @@ function SEO({ description, lang, meta, title }) {
       )
       if (foundScript) {
         foundScript.onload = () => window.feedback.init({ showIcon: false })
+        setIsFBMLoaded(true)
       }
     }
   }

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react"
+import React, { useContext } from "react"
 
 import Layout, {
   PageBody,
@@ -9,20 +9,10 @@ import Layout, {
 import SEO from "../components/seo"
 import ExternalLink from "../components/external-link"
 import Button from "../components/button"
+import { FBMContext } from "../components/fbm-provider"
 
 const Contact = () => {
-  const [isFBMLoaded, setIsFBMLoaded] = useState(false)
-
-  useEffect(() => {
-    // ensure that feedback module is loaded and inititalized
-    // (external script added via Helmet (see seo.js))
-    if (window.feedback) {
-      if (!window.feedback.showForm) {
-        window.feedback.init({ showIcon: false })
-      }
-      setIsFBMLoaded(true)
-    }
-  }, [])
+  const { isFBMLoaded } = useContext(FBMContext)
 
   return (
     <Layout>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react"
+import React, { useContext } from "react"
 import PropTypes from "prop-types"
 import { graphql, Link } from "gatsby"
 
@@ -15,20 +15,10 @@ import { InstrumentsGrid } from "../components/home/instruments-grid"
 import { ArrowIcon } from "../icons"
 import { NEGATIVE } from "../utils/constants"
 import { colors } from "../theme"
+import { FBMContext } from "../components/fbm-provider"
 
 const Home = ({ data }) => {
-  const [isFBMLoaded, setIsFBMLoaded] = useState(false)
-
-  useEffect(() => {
-    // ensure that feedback module is loaded and inititalized
-    // (external script added via Helmet (see seo.js))
-    if (window.feedback) {
-      if (!window.feedback.showForm) {
-        window.feedback.init({ showIcon: false })
-      }
-      setIsFBMLoaded(true)
-    }
-  }, [])
+  const { isFBMLoaded } = useContext(FBMContext)
 
   return (
     <Layout>


### PR DESCRIPTION
This is just a code cleanup around the feedback module, which leads to more reliably display of the feedback button (after the module is loaded). 

The feedback module itself seem to have been fixed on production already (thanks to @xhagrg ?)