### PR TITLE
Replace form iframe with link

### DIFF
--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react"
+import React, { useContext } from "react"
 
 import Layout, {
   PageBody,
@@ -8,13 +8,10 @@ import Layout, {
 } from "../components/layout"
 import SEO from "../components/seo"
 import ExternalLink from "../components/external-link"
-import Button from "../components/button"
 import { FBMContext } from "../components/fbm-provider"
-import { Modal } from "../components/modal"
 
 const Contact = () => {
   const { isFBMLoaded } = useContext(FBMContext)
-  const [showModal, setShowModal] = useState(false)
 
   return (
     <Layout>
@@ -67,17 +64,16 @@ const Contact = () => {
               {isFBMLoaded && (
                 <>
                   click{" "}
-                  <Button
-                    action={() => {
-                      setShowModal(true)
-                    }}
-                  >
-                    here
-                  </Button>{" "}
+                  <ExternalLink
+                    url="https://docs.google.com/forms/d/e/1FAIpQLSfCQzZHtaDSiWNdwiJa3TIzsyhjEbYyyHwfrcwIKn_UmdVaKA/viewform?usp=sf_link"
+                    target="_blank"
+                    label="CASEI feedback"
+                    id="feedback form"
+                  />{" "}
                   or{" "}
                 </>
               )}
-              contact
+              contact{" "}
               <ExternalLink
                 url="mailto:info@developmentseed.org"
                 label="info@developmentseed.org"
@@ -88,28 +84,6 @@ const Contact = () => {
           </SectionContent>
         </Section>
       </PageBody>
-      <Modal
-        id="modal"
-        isOpen={showModal}
-        handleClose={() => setShowModal(false)}
-      >
-        <iframe
-          src="https://docs.google.com/forms/d/e/1FAIpQLSfCQzZHtaDSiWNdwiJa3TIzsyhjEbYyyHwfrcwIKn_UmdVaKA/viewform?embedded=true"
-          embedded={true}
-          width="100%"
-          height="100%"
-          frameBorder="0"
-          marginHeight="0"
-          marginWidth="0"
-          css={`
-            border: unset;
-            box-sizing: border-box;
-            width: calc(100% + 20px);
-          `}
-        >
-          Loading…
-        </iframe>
-      </Modal>
     </Layout>
   )
 }


### PR DESCRIPTION
This is a quick workaround to avoid the issue caused by csp blocking of the google form in the i-frame. I am replacing the i-frame with an external link to the google form, which will open in a separate tab. 

<img width="1908" alt="Screen Shot 2022-12-13 at 3 07 14 PM" src="https://user-images.githubusercontent.com/31222040/207464418-6db63077-082a-436b-a44d-ceacd9e1bb81.png">
