### PR TITLE
remove target dir in deploy to staging CI, targets root by default

### DIFF
--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -68,4 +68,3 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_ALICER_DEVSEED }}
           AWS_REGION: "us-east-1" # optional: defaults to us-east-1
           SOURCE_DIR: "public"
-          DEST_DIR: "casei"


### PR DESCRIPTION
removes target dir "casei" from the `deploy to staging` CI workflow configuration. The CI will instead target root of the S3 bucket by default. 