### PR TITLE
Removed header text check on after explore page navigation. 

### DIFF
--- a/playwright/e2e/home.spec.ts
+++ b/playwright/e2e/home.spec.ts
@@ -1,210 +1,244 @@
-const { test, expect } = require('@playwright/test');
-import { site } from "../../test/__fixtures__";
+const { test, expect } = require("@playwright/test")
+import { site } from "../../test/__fixtures__"
 import config from "../playwright.config"
 const baseUrl = config.use?.baseURL
 
 // TODO, review if this is still needed
 const checkSectionHeader = async (page, section, headerText) => {
-    const header = await page.$(`data-cy=${section}-section >> h2`);
-    const headerContent = await header.textContent();
-    expect(headerContent).toBe(headerText);
-};
+  const header = await page.$(`data-cy=${section}-section >> h2`)
+  const headerContent = await header.textContent()
+  expect(headerContent).toBe(headerText)
+}
 
-test.describe('Homepage', () => {
-    let page;
+test.describe("Homepage", () => {
+  let page
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-        await page.goto(baseUrl);
-    });
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage()
+    await page.goto(baseUrl)
+  })
 
-    test.afterAll(async () => {
-        await page.close();
-    });
+  test.afterAll(async () => {
+    await page.close()
+  })
 
-    test.describe('Home Hero section', () => {
-        test('renders title and description correctly', async ({ page }) => {
+  test.describe("Home Hero section", () => {
+    test("renders title and description correctly", async ({ page }) => {
+      await page.goto(baseUrl)
+      // Check if the home hero section exists and has a single instance
+      const homeHero = await page.$("[data-cy=home-hero]")
+      expect(homeHero).not.toBeNull()
 
-            await page.goto(baseUrl);
-            // Check if the home hero section exists and has a single instance
-            const homeHero = await page.$('[data-cy=home-hero]');
-            expect(homeHero).not.toBeNull();
+      // Check if the title in the home hero section matches the expected title
+      const titleElement = await homeHero.$("h1")
+      const titleContent = await titleElement.textContent()
+      expect(titleContent).not.toBeNull()
 
-            // Check if the title in the home hero section matches the expected title
-            const titleElement = await homeHero.$('h1');
-            const titleContent = await titleElement.textContent();
-            expect(titleContent).not.toBeNull();
+      // toMatch(site.siteMetadata.title.toString()); // TODO toMatch and textContent failing to match identical strings
 
-            // toMatch(site.siteMetadata.title.toString()); // TODO toMatch and textContent failing to match identical strings
+      // Check if the description in the home hero section matches the expected description
+      const descriptionElement = await page.locator("[data-cy=home-hero] p")
+      const descriptionContent = await descriptionElement.textContent()
+      expect(descriptionContent).not.toBeNull()
 
-            // Check if the description in the home hero section matches the expected description
-            const descriptionElement = await page.locator('[data-cy=home-hero] p');
-            const descriptionContent = await descriptionElement.textContent();
-            expect(descriptionContent).not.toBeNull();
+      // (site.siteMetadata.description); TODO
+    })
+  })
 
-            // (site.siteMetadata.description); TODO
-        });
-    });
+  test.describe("Focus Area section", () => {
+    test("focus areas can be selected", async ({ page }) => {
+      await page.goto(baseUrl + "/focus/Weather/")
+      // Check if the focus area section exists and contains the expected header
+      const focusAreaHeader = await page.$(
+        "[data-cy=focus-areas-section] >> h2"
+      )
+      expect(focusAreaHeader).not.toBeNull()
 
+      // Check if focus area elements contain the expected SVG icons and labels
+      const focusAreas = await page.$$(
+        "[data-cy=focus-areas-section] >> [data-cy=focus-area]"
+      )
+      for (const focusArea of focusAreas) {
+        const svgElement = await focusArea.$("svg")
+        expect(svgElement).toBeTruthy()
 
-    test.describe('Focus Area section', () => {
-        test('focus areas can be selected', async ({ page }) => {
+        const viewBox = await svgElement.getAttribute("viewBox")
+        expect(viewBox).not.toBe("0 0 16 16")
 
-            await page.goto(baseUrl + '/focus/Weather/');
-            // Check if the focus area section exists and contains the expected header
-            const focusAreaHeader = await page.$('[data-cy=focus-areas-section] >> h2');
-            expect(focusAreaHeader).not.toBeNull();
+        const labelElement = await focusArea.$("label")
+        const labelText = await labelElement.textContent()
+        expect(labelText).toBe(await focusArea.textContent())
+      }
 
-            // Check if focus area elements contain the expected SVG icons and labels
-            const focusAreas = await page.$$('[data-cy=focus-areas-section] >> [data-cy=focus-area]');
-            for (const focusArea of focusAreas) {
-                const svgElement = await focusArea.$('svg');
-                expect(svgElement).toBeTruthy();
+      // Click on a focus area and verify that the URL changes as expected
+      const weatherFocusArea = await page.$(
+        "[data-cy=focus-areas-section] >> [data-cy=focus-area] >> text=Weather"
+      )
+      await weatherFocusArea.click()
 
-                const viewBox = await svgElement.getAttribute('viewBox');
-                expect(viewBox).not.toBe('0 0 16 16');
+      expect(await page.url()).toContain("/focus/")
 
-                const labelElement = await focusArea.$('label');
-                const labelText = await labelElement.textContent();
-                expect(labelText).toBe(await focusArea.textContent());
-            }
+      // Verify that the new page has the expected header
+      const newHeader = await page.textContent("h1")
+      expect(newHeader).toBe("Weather")
+    })
+  })
 
-            // Click on a focus area and verify that the URL changes as expected
-            const weatherFocusArea = await page.$('[data-cy=focus-areas-section] >> [data-cy=focus-area] >> text=Weather');
-            await weatherFocusArea.click();
+  test.describe("Explore section", () => {
+    test("there is an explore section", async ({ page }) => {
+      await page.goto(baseUrl)
 
-            expect(await page.url()).toContain('/focus/');
+      // Check if the explore section exists and contains the expected header
+      const exploreHeader = await page.textContent(
+        "[data-cy=explore-section] >> h2"
+      )
+      expect(exploreHeader).toBe("CASEI")
 
-            // Verify that the new page has the expected header
-            const newHeader = await page.textContent('h1');
-            expect(newHeader).toBe('Weather');
-        });
-    });
+      // Check if the explore link list exists and contains the expected number of items
+      const exploreItems = await page.$$("[data-cy=explore-link-list] >> li")
+      expect(exploreItems).toHaveLength(3)
 
+      // Check if the explore items have the expected text content
+      expect(await exploreItems[0].textContent()).toContain("Explore campaigns")
+      expect(await exploreItems[1].textContent()).toContain("Explore platforms")
+      expect(await exploreItems[2].textContent()).toContain(
+        "Explore instruments"
+      )
+    })
+  })
 
-    test.describe('Explore section', () => {
-        test('there is an explore section', async ({ page }) => {
+  test.describe("Region Type section", () => {
+    test("region types can be selected", async ({ page }) => {
+      await page.goto(baseUrl)
 
-            await page.goto(baseUrl);
+      // Check if the region type section exists and contains the expected header
+      const regionTypeHeader = await page.textContent(
+        "[data-cy=region-type-section] >> h2"
+      )
+      expect(regionTypeHeader).toBe("Region Type")
 
-            // Check if the explore section exists and contains the expected header
-            const exploreHeader = await page.textContent('[data-cy=explore-section] >> h2');
-            expect(exploreHeader).toBe('CASEI');
+      // Check the number of region type buttons and store their text content
+      const regionButtons = await page.$$(
+        "[data-cy=region-text-control] >> button"
+      )
+      expect(regionButtons).toHaveLength(16)
+      const regionButtonTexts = await Promise.all(
+        regionButtons.map(button => button.textContent())
+      )
 
-            // Check if the explore link list exists and contains the expected number of items
-            const exploreItems = await page.$$('[data-cy=explore-link-list] >> li');
-            expect(exploreItems).toHaveLength(3);
+      // Check the number of region type items and compare their text content with the buttons
+      const regionTypes = await page.$$(
+        "[data-cy=region-type-section] >> [data-cy=region-type] >> [data-cy=region-type-name]"
+      )
+      expect(regionTypes).toHaveLength(16)
+      const regionTypeTexts = await Promise.all(
+        regionTypes.map(regionType => regionType.textContent())
+      )
+      expect(regionButtonTexts).toEqual(regionTypeTexts)
 
-            // Check if the explore items have the expected text content
-            expect(await exploreItems[0].textContent()).toContain('Explore campaigns');
-            expect(await exploreItems[1].textContent()).toContain('Explore platforms');
-            expect(await exploreItems[2].textContent()).toContain('Explore instruments');
-        });
-    });
+      // Click on the "Island" region type button
+      await page.click("[data-cy=region-text-control] >> text=/Island/i")
 
+      // Check if the "Island" region type is visible
+      expect(
+        await page.isVisible(
+          "[data-cy=region-type-section] >> [data-cy=region-type-name] >> text=/Island/i"
+        )
+      ).toBeTruthy()
 
-    test.describe('Region Type section', () => {
-        test('region types can be selected', async ({ page }) => {
+      // Click on the "Mountains" region type button
+      await page.click("[data-cy=region-text-control] >> text=/Mountains/i")
 
-            await page.goto(baseUrl);
+      // Check if the "Mountains" region type is visible
+      expect(
+        await page.isVisible(
+          "[data-cy=region-type-section] >> [data-cy=region-type-name] >> text=/Mountains/i"
+        )
+      ).toBeTruthy()
 
-            // Check if the region type section exists and contains the expected header
-            const regionTypeHeader = await page.textContent('[data-cy=region-type-section] >> h2');
-            expect(regionTypeHeader).toBe('Region Type');
+      // Click on the visible region type item
+      await page.click('div[class="slider-slide slide-visible slide-current"]')
 
-            // Check the number of region type buttons and store their text content
-            const regionButtons = await page.$$('[data-cy=region-text-control] >> button');
-            expect(regionButtons).toHaveLength(16);
-            const regionButtonTexts = await Promise.all(regionButtons.map(button => button.textContent()));
+      // wait for page load
+      await page.waitForNavigation()
 
-            // Check the number of region type items and compare their text content with the buttons
-            const regionTypes = await page.$$('[data-cy=region-type-section] >> [data-cy=region-type] >> [data-cy=region-type-name]');
-            expect(regionTypes).toHaveLength(16);
-            const regionTypeTexts = await Promise.all(regionTypes.map(regionType => regionType.textContent()));
-            expect(regionButtonTexts).toEqual(regionTypeTexts);
+      // Check if the URL includes "/explore/campaigns" and the header has the expected text
+      expect(page.url()).toContain("/explore/campaigns")
+    })
+  })
 
-            // Click on the "Island" region type button
-            await page.click('[data-cy=region-text-control] >> text=/Island/i');
+  test.describe("Geophysical Concepts section", () => {
+    test("geophysical concepts can be selected", async ({ page }) => {
+      await page.goto(baseUrl)
 
-            // Check if the "Island" region type is visible
-            expect(await page.isVisible('[data-cy=region-type-section] >> [data-cy=region-type-name] >> text=/Island/i')).toBeTruthy();
+      // Check if the geophysical concepts section exists and contains the expected header
+      const geophysicalConceptsHeader = await page.textContent(
+        "[data-cy=geophysical-concepts-section] >> h2"
+      )
+      expect(geophysicalConceptsHeader).toBe("Geophysical Concepts")
 
-            // Click on the "Mountains" region type button
-            await page.click('[data-cy=region-text-control] >> text=/Mountains/i');
+      // Retrieve geophysical concept elements and their text content
+      const geophysicalConcepts = await page.$$(
+        "[data-cy=geophysical-concepts-section] >> [data-cy=geophysical-concept]"
+      )
+      const geophysicalConceptsTexts = await Promise.all(
+        geophysicalConcepts.map(concept => concept.textContent())
+      )
 
-            // Check if the "Mountains" region type is visible
-            expect(await page.isVisible('[data-cy=region-type-section] >> [data-cy=region-type-name] >> text=/Mountains/i')).toBeTruthy();
+      // Check if the div elements inside the geophysical concepts have the expected text content
+      for (const conceptText of geophysicalConceptsTexts) {
+        expect(
+          await page.isVisible(
+            `[data-cy=geophysical-concepts-section] >> [data-cy=geophysical-concept] >> text=${conceptText}`
+          )
+        ).toBeTruthy()
+      }
 
-            // Click on the visible region type item
-            await page.click('div[class="slider-slide slide-visible slide-current"]');
+      // Click on the "Biodiversity" geophysical concept
+      await page.click(
+        "[data-cy=geophysical-concepts-section] >> [data-cy=geophysical-concept] >> text=Biodiversity"
+      )
 
-            // wait for page load
-            await page.waitForNavigation();
+      // wait for page load
+      await page.waitForNavigation()
 
-            // Check if the URL includes "/explore/campaigns" and the header has the expected text
-            expect(page.url()).toContain('/explore/campaigns');
-            const headerText = await page.textContent('h1');
-            expect(headerText).toContain('Explore');
-        });
-    });
+      // Check if the URL includes "/explore/campaigns" and the header has the expected text
+      expect(page.url()).toContain("/explore/campaigns")
+      const filterChip = await page.textContent('[data-cy="filter-chip"]')
+      expect(filterChip).toBe("geophysical: Biodiversity")
+    })
+  })
 
+  test.describe("Instruments section", () => {
+    test("an instrument can be selected", async ({ page }) => {
+      await page.goto(baseUrl)
 
-    test.describe('Geophysical Concepts section', () => {
-        test('geophysical concepts can be selected', async ({ page }) => {
+      // Check if the instruments section exists and contains the expected header
+      const instrumentsHeader = await page.textContent(
+        "[data-cy=instruments-section] >> h2"
+      )
+      expect(instrumentsHeader).toBe("Measurement Type")
 
-            await page.goto(baseUrl);
+      // Check if the "Spectrometer/Radiometer" instrument type is visible
+      expect(
+        await page.isVisible(
+          "[data-cy=instruments-section] >> [data-cy=instrument-type] >> text=Spectrometer/Radiometer"
+        )
+      ).toBeTruthy()
 
-            // Check if the geophysical concepts section exists and contains the expected header
-            const geophysicalConceptsHeader = await page.textContent('[data-cy=geophysical-concepts-section] >> h2');
-            expect(geophysicalConceptsHeader).toBe('Geophysical Concepts');
+      // Click on the "Spectrometer/Radiometer" instrument type
+      await page.click(
+        "[data-cy=instruments-section] >> [data-cy=instrument-type] >> text=Spectrometer/Radiometer"
+      )
 
-            // Retrieve geophysical concept elements and their text content
-            const geophysicalConcepts = await page.$$('[data-cy=geophysical-concepts-section] >> [data-cy=geophysical-concept]');
-            const geophysicalConceptsTexts = await Promise.all(geophysicalConcepts.map(concept => concept.textContent()));
+      // wait for page load
+      await page.waitForNavigation()
 
-            // Check if the div elements inside the geophysical concepts have the expected text content
-            for (const conceptText of geophysicalConceptsTexts) {
-                expect(await page.isVisible(`[data-cy=geophysical-concepts-section] >> [data-cy=geophysical-concept] >> text=${conceptText}`)).toBeTruthy();
-            }
+      // Check if the URL includes "/explore/instruments" and the header has the expected text
+      expect(page.url()).toContain("/explore/instruments")
 
-            // Click on the "Biodiversity" geophysical concept
-            await page.click('[data-cy=geophysical-concepts-section] >> [data-cy=geophysical-concept] >> text=Biodiversity');
-
-            // wait for page load
-            await page.waitForNavigation();
-
-            // Check if the URL includes "/explore/campaigns" and the header has the expected text
-            expect(page.url()).toContain('/explore/campaigns');
-            const filterChip = await page.textContent('[data-cy="filter-chip"]');
-            expect(filterChip).toBe("geophysical: Biodiversity");
-        });
-    });
-
-
-    test.describe('Instruments section', () => {
-        test('an instrument can be selected', async ({ page }) => {
-
-            await page.goto(baseUrl);
-
-            // Check if the instruments section exists and contains the expected header
-            const instrumentsHeader = await page.textContent('[data-cy=instruments-section] >> h2');
-            expect(instrumentsHeader).toBe('Measurement Type');
-
-            // Check if the "Spectrometer/Radiometer" instrument type is visible
-            expect(await page.isVisible('[data-cy=instruments-section] >> [data-cy=instrument-type] >> text=Spectrometer/Radiometer')).toBeTruthy();
-
-            // Click on the "Spectrometer/Radiometer" instrument type
-            await page.click('[data-cy=instruments-section] >> [data-cy=instrument-type] >> text=Spectrometer/Radiometer');
-
-            // wait for page load
-            await page.waitForNavigation();
-
-            // Check if the URL includes "/explore/instruments" and the header has the expected text
-            expect(page.url()).toContain('/explore/instruments');
-
-            const filterChip = await page.textContent('[data-cy="filter-chip"]');
-            expect(filterChip).toBe('type: Spectrometer/Radiometer');
-        });
-    });
-
-});
+      const filterChip = await page.textContent('[data-cy="filter-chip"]')
+      expect(filterChip).toBe("type: Spectrometer/Radiometer")
+    })
+  })
+})


### PR DESCRIPTION
We already check that the URL is correct and don't also need to validate the content of the page.

This fixes an E2E test that was broken in production.