### PR TITLE
Add json field guard

### DIFF
--- a/src/pages/explore/products.js
+++ b/src/pages/explore/products.js
@@ -140,7 +140,13 @@ export default function ExploreProducts({ data, location }) {
   for (const doi of allShapedDoi) {
     // The doi keywords are stored as a JSON string in the database
     // parsing them here into an object
-    const keywords = JSON.parse(doi.keywords)
+    let keywords = []
+    try {
+      keywords = JSON.parse(doi.keywords)
+    } catch (e) {
+      console.error(`ERROR: Could not parse ${doi.keywords}`)
+    }
+
     if (
       keywords?.length &&
       keywords != "null" &&

--- a/src/utils/filter-utils.js
+++ b/src/utils/filter-utils.js
@@ -120,7 +120,14 @@ export function productsFilter(selectedFilterIds) {
     )
 
     const gcmdKeywords = new Set()
-    const keywords = JSON.parse(product.keywords)
+    // guard against maleformed json fields
+    let keywords = []
+    try {
+      keywords = JSON.parse(product.keywords)
+    } catch (e) {
+      console.error(`ERROR: Could not parse ${product.keywords}`)
+    }
+
     if (
       keywords?.length &&
       keywords != "null" &&


### PR DESCRIPTION
## What I'm changing
This is a quick fix to guard against JSON fields that are not in a correct formatting for parsing in the frontend. The one fix address the build error we just encountered in production the other change is for run time issues that would arise when using filters on the data products page. 