### PR TITLE
Deal with campaigns and deployments with slashes in the name

### DIFF
--- a/src/components/timeline/map.js
+++ b/src/components/timeline/map.js
@@ -9,6 +9,7 @@ import { getUniquePlatforms } from "../../utils/get-unique-platforms"
 import { LineIcon, CircleIcon } from "../../icons"
 import { mapLayerFilter } from "../../utils/filter-utils"
 import { colors } from "../../theme"
+import { replaceSlashes } from "../../utils/helpers"
 
 export function DeploymentMap({
   geojson,
@@ -53,7 +54,9 @@ export function DeploymentMap({
             onLoad={map => map.fitBounds(bounds, { padding: 50 })}
             selectedPlatforms={selectedPlatforms}
             selectedDeployment={
-              selectedDeployment ? selectedDeployment.longname : ""
+              selectedDeployment
+                ? replaceSlashes(selectedDeployment.longname)
+                : ""
             }
           />
           <DeploymentLayer
@@ -86,7 +89,9 @@ export function DeploymentMap({
             }}
             selectedPlatforms={selectedPlatforms}
             selectedDeployment={
-              selectedDeployment ? selectedDeployment.longname : ""
+              selectedDeployment
+                ? replaceSlashes(selectedDeployment.longname)
+                : ""
             }
           />
         </Source>
@@ -158,6 +163,7 @@ export const MapLegend = ({
   const uniquePlatforms = platforms.filter(
     (i, index) => names.indexOf(i.name) === index
   )
+
   return (
     <LegendBox>
       <fieldset>

--- a/src/components/timeline/timeline-chart.js
+++ b/src/components/timeline/timeline-chart.js
@@ -12,6 +12,7 @@ import { Deployment } from "./deployment"
 import { Disclosure } from "@reach/disclosure"
 import { DeploymentPanel } from "./deployment-panel"
 import { DeploymentMap } from "./map"
+import { replaceSlashes } from "../../utils/helpers"
 
 const chartSettings = {
   marginTop: 1,
@@ -92,12 +93,15 @@ export const TimelineChart = ({ deployments, bounds, campaignName }) => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await fetch(`/flight-tracks/${campaignName}.geojson`, {
-          method: "GET",
-          headers: {
-            "Content-Type": "application/json",
-          },
-        })
+        const response = await fetch(
+          `/flight-tracks/${replaceSlashes(campaignName)}.geojson`,
+          {
+            method: "GET",
+            headers: {
+              "Content-Type": "application/json",
+            },
+          }
+        )
         const vals = await response.json()
         setGeojson(vals)
       } catch (error) {

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -119,3 +119,5 @@ export function convertBoundsToNSWE(bounds) {
 }
 
 export const reformatDate = dateString => dateString.split("-").join("/")
+
+export const replaceSlashes = str => str.replaceAll("/", "-")


### PR DESCRIPTION
[This campaign](https://impact.earthdata.nasa.gov/casei/campaign/Aeolus%20Cal/Val) has a slash in its name and in the deployment name. It's necessary to deal with that when loading the geojson file and when filtering features in the map.