### PR TITLE
Fix feedback form link

### DIFF
--- a/src/components/inpage-nav.js
+++ b/src/components/inpage-nav.js
@@ -1,6 +1,6 @@
 import React from "react"
 import PropTypes from "prop-types"
-import { POSITIVE } from "../utils/constants"
+import { FEEDBACK_FORM_URL, POSITIVE } from "../utils/constants"
 import { colors, breakpoints } from "../theme"
 import Button from "../components/button"
 import StickyBanner from "./sticky-banner"
@@ -107,7 +107,7 @@ const InpageNav = ({ shortname, items }) => {
           {
             <Button
               action={() => {
-                window.feedback.showForm()
+                window.open(FEEDBACK_FORM_URL, "_blank")
               }}
               mode={POSITIVE}
             >


### PR DESCRIPTION
Closes #646 

This PR fixes the broken feedback form link found on the `inpagenav`. The previous feedback form was modified in multiple PR's, but old behavior (opening a FBM/Kayako form, and then a google form, in an iframed modal) had not been updated in the code.

The feedback link now opens a google form in a new tab, which is consistent with the behavior found on the Contact page.

https://github.com/NASA-IMPACT/admg-casei/assets/12634024/2a07c503-aa42-4cd7-8394-7d2a85f05ebb


