### PR TITLE
Update styles for accordion: links and background

### DIFF
--- a/src/components/accordion.js
+++ b/src/components/accordion.js
@@ -22,6 +22,17 @@ export const RotatingContainer = styled.div`
   transform: ${({ isExpanded }) =>
     isExpanded ? "rotate(180deg)" : "rotate(0deg)"};
 `
+const LearnMoreLink = styled.label`
+  color: ${colors[NEGATIVE].linkText};
+  display: flex;
+  justify-content: flex-end;
+  & a {
+    display: flex;
+    align-items: center;
+    color: ${colors[NEGATIVE].linkText};
+    cursor: pointer;
+  }
+`
 
 export default function Accordion({ folds, id }) {
   const [indices, setIndices] = useState([])
@@ -59,6 +70,7 @@ export default function Accordion({ folds, id }) {
                 padding: 1rem;
                 text-transform: none;
                 font-weight: bold;
+                font-size: 1rem;
                 justify-content: space-between;
                 display: flex;
               }
@@ -77,8 +89,9 @@ export default function Accordion({ folds, id }) {
           <AccordionPanel
             css={`
                {
-                padding: 0.5rem 1rem;
+                padding: 1rem;
                 cursor: default;
+                background: rgba(235, 235, 248, 0.05);
               }
             `}
           >
@@ -144,25 +157,15 @@ export default function Accordion({ folds, id }) {
                 ))}
               </div>
             )}
-            <Label
-              id="accordion-link"
-              display="flex"
-              color={colors[NEGATIVE].linkText}
-            >
+            <LearnMoreLink id="accordion-link">
               <Link
                 to={`/instrument/${fold.shortname}`}
-                css={`
-                   {
-                    color: ${colors[NEGATIVE].linkText};
-                    cursor: pointer;
-                  }
-                `}
                 data-cy="accordion-link"
               >
                 Learn More
                 <ArrowIcon color={colors[NEGATIVE].linkText} />
               </Link>
-            </Label>
+            </LearnMoreLink>
           </AccordionPanel>
         </AccordionItem>
       ))}

--- a/src/components/accordion.js
+++ b/src/components/accordion.js
@@ -25,7 +25,7 @@ export const RotatingContainer = styled.div`
 const LearnMoreLink = styled.label`
   color: ${colors[NEGATIVE].linkText};
   display: flex;
-  justify-content: flex-end;
+  margin-left: 2rem;
   & a {
     display: flex;
     align-items: center;
@@ -89,7 +89,7 @@ export default function Accordion({ folds, id }) {
           <AccordionPanel
             css={`
                {
-                padding: 1rem;
+                padding: 1.5rem 1rem;
                 cursor: default;
                 background: rgba(235, 235, 248, 0.05);
               }
@@ -145,7 +145,7 @@ export default function Accordion({ folds, id }) {
               <div
                 css={`
                    {
-                    margin: 3rem 0;
+                    margin: 2rem 0;
                   }
                 `}
               >

--- a/src/templates/campaign/__tests__/__snapshots__/platform-section.test.js.snap
+++ b/src/templates/campaign/__tests__/__snapshots__/platform-section.test.js.snap
@@ -181,7 +181,7 @@ exports[`Platform Section displays content 1`] = `
               </button>
               <div
                 aria-labelledby="button---1"
-                className="accordion___StyledAccordionPanel-sc-1dzvn26-4 fmEtpI"
+                className="accordion___StyledAccordionPanel-sc-1dzvn26-4 kArqvk"
                 data-reach-accordion-panel=""
                 data-state="collapsed"
                 hidden={true}
@@ -198,7 +198,7 @@ exports[`Platform Section displays content 1`] = `
                   />
                 </div>
                 <label
-                  className="accordion__LearnMoreLink-sc-1dzvn26-1 iwwSoJ"
+                  className="accordion__LearnMoreLink-sc-1dzvn26-1 hTfybq"
                   id="accordion-link"
                 >
                   <a
@@ -368,7 +368,7 @@ exports[`Platform Section displays content 1`] = `
               </button>
               <div
                 aria-labelledby="button---1"
-                className="accordion___StyledAccordionPanel-sc-1dzvn26-4 fmEtpI"
+                className="accordion___StyledAccordionPanel-sc-1dzvn26-4 kArqvk"
                 data-reach-accordion-panel=""
                 data-state="collapsed"
                 hidden={true}
@@ -385,7 +385,7 @@ exports[`Platform Section displays content 1`] = `
                   />
                 </div>
                 <label
-                  className="accordion__LearnMoreLink-sc-1dzvn26-1 iwwSoJ"
+                  className="accordion__LearnMoreLink-sc-1dzvn26-1 hTfybq"
                   id="accordion-link"
                 >
                   <a

--- a/src/templates/campaign/__tests__/__snapshots__/platform-section.test.js.snap
+++ b/src/templates/campaign/__tests__/__snapshots__/platform-section.test.js.snap
@@ -131,7 +131,7 @@ exports[`Platform Section displays content 1`] = `
             </div>
           </div>
           <div
-            className="accordion___StyledReachAccordion-sc-1dzvn26-1 fiUaUQ"
+            className="accordion___StyledReachAccordion-sc-1dzvn26-2 MQLQP"
             data-cy="instrument-accordion"
             data-reach-accordion=""
           >
@@ -142,7 +142,7 @@ exports[`Platform Section displays content 1`] = `
               <button
                 aria-controls="panel---1"
                 aria-expanded={false}
-                className="accordion___StyledAccordionButton-sc-1dzvn26-2 ihAXTv"
+                className="accordion___StyledAccordionButton-sc-1dzvn26-3 hLJNUX"
                 data-cy="accordion-button"
                 data-reach-accordion-button=""
                 data-state="collapsed"
@@ -181,7 +181,7 @@ exports[`Platform Section displays content 1`] = `
               </button>
               <div
                 aria-labelledby="button---1"
-                className="accordion___StyledAccordionPanel-sc-1dzvn26-3 ctpjXv"
+                className="accordion___StyledAccordionPanel-sc-1dzvn26-4 fmEtpI"
                 data-reach-accordion-panel=""
                 data-state="collapsed"
                 hidden={true}
@@ -189,20 +189,19 @@ exports[`Platform Section displays content 1`] = `
                 role="region"
               >
                 <div
-                  className="accordion___StyledDiv-sc-1dzvn26-4 bgnPyw"
+                  className="accordion___StyledDiv-sc-1dzvn26-5 eTJAMp"
                   data-cy="instrument-accordion-content"
                 >
                   <div
-                    className="accordion___StyledDiv3-sc-1dzvn26-7 hRjfzT"
+                    className="accordion___StyledDiv3-sc-1dzvn26-8 jCeKDA"
                     data-cy="instrument-accordion-image-description"
                   />
                 </div>
                 <label
-                  className="label___StyledLabel-sc-b3994k-0 jmRbyG"
-                  data-cy="accordion-link-label"
+                  className="accordion__LearnMoreLink-sc-1dzvn26-1 iwwSoJ"
+                  id="accordion-link"
                 >
                   <a
-                    className="accordion___StyledLink-sc-1dzvn26-9 bIlZXf"
                     data-cy="accordion-link"
                     href="/instrument/CAR"
                   >
@@ -319,7 +318,7 @@ exports[`Platform Section displays content 1`] = `
             </div>
           </div>
           <div
-            className="accordion___StyledReachAccordion-sc-1dzvn26-1 fiUaUQ"
+            className="accordion___StyledReachAccordion-sc-1dzvn26-2 MQLQP"
             data-cy="instrument-accordion"
             data-reach-accordion=""
           >
@@ -330,7 +329,7 @@ exports[`Platform Section displays content 1`] = `
               <button
                 aria-controls="panel---1"
                 aria-expanded={false}
-                className="accordion___StyledAccordionButton-sc-1dzvn26-2 ihAXTv"
+                className="accordion___StyledAccordionButton-sc-1dzvn26-3 hLJNUX"
                 data-cy="accordion-button"
                 data-reach-accordion-button=""
                 data-state="collapsed"
@@ -369,7 +368,7 @@ exports[`Platform Section displays content 1`] = `
               </button>
               <div
                 aria-labelledby="button---1"
-                className="accordion___StyledAccordionPanel-sc-1dzvn26-3 ctpjXv"
+                className="accordion___StyledAccordionPanel-sc-1dzvn26-4 fmEtpI"
                 data-reach-accordion-panel=""
                 data-state="collapsed"
                 hidden={true}
@@ -377,20 +376,19 @@ exports[`Platform Section displays content 1`] = `
                 role="region"
               >
                 <div
-                  className="accordion___StyledDiv-sc-1dzvn26-4 bgnPyw"
+                  className="accordion___StyledDiv-sc-1dzvn26-5 eTJAMp"
                   data-cy="instrument-accordion-content"
                 >
                   <div
-                    className="accordion___StyledDiv3-sc-1dzvn26-7 hRjfzT"
+                    className="accordion___StyledDiv3-sc-1dzvn26-8 jCeKDA"
                     data-cy="instrument-accordion-image-description"
                   />
                 </div>
                 <label
-                  className="label___StyledLabel-sc-b3994k-0 jmRbyG"
-                  data-cy="accordion-link-label"
+                  className="accordion__LearnMoreLink-sc-1dzvn26-1 iwwSoJ"
+                  id="accordion-link"
                 >
                   <a
-                    className="accordion___StyledLink-sc-1dzvn26-9 bIlZXf"
                     data-cy="accordion-link"
                     href="/instrument/Pyrometer"
                   >


### PR DESCRIPTION
Resolves comments in https://github.com/NASA-IMPACT/ADMG-project/issues/1103.

This PR:
- Shifts the "Learn More" link to the right side of the accordion fold
- Adds a light background to the accordion fold to more clearly visually distinguish each accordion section from the next

<img width="970" alt="image" src="https://github.com/NASA-IMPACT/admg-casei/assets/12634024/e7b2e563-d2b2-409d-b536-687c85264b27">