### PR TITLE
Add pathprefix to homepage campaign timeline links

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,7 +3,7 @@ require("dotenv").config({
 })
 
 module.exports = {
-  pathPrefix: `/casei`,
+  pathPrefix: process.env.NODE_ENV === "development" ? "" : `/casei`,
   siteMetadata: {
     title: `Catalog of Archived Suborbital Earth Science Investigations`,
     shortname: `NASA | CASEI`,

--- a/src/components/home/campaigns-timeline.js
+++ b/src/components/home/campaigns-timeline.js
@@ -7,6 +7,9 @@ import "./timeline-styles.css"
 export const CampaignsTimeline = ({}) => {
   const data = useStaticQuery(graphql`
     query {
+      site {
+        pathPrefix
+      }
       allCampaign {
         nodes {
           logo {
@@ -33,7 +36,7 @@ export const CampaignsTimeline = ({}) => {
           ? campaign.logo?.gatsbyImg.childImageSharp.gatsbyImageData.images
               .fallback.src
           : "",
-        link: `/campaign/${campaign.shortname}`,
+        link: `${data.site.pathPrefix}/campaign/${campaign.shortname}`,
         thumbnail: campaign.logo
           ? campaign.logo?.gatsbyImg.childImageSharp.gatsbyImageData.images
               .fallback.src
@@ -65,7 +68,7 @@ export const CampaignsTimeline = ({}) => {
                 (campaign.description.length > 650 ? "..." : "")
           }
           </p>` +
-          `<a class="tl-button button-clickable" href="/campaign/${campaign.shortname}" target="_self">View campaign</a>`,
+          `<a class="tl-button button-clickable" href="${data.site.pathPrefix}/campaign/${campaign.shortname}" target="_self">View campaign</a>`,
       },
     })),
   }


### PR DESCRIPTION
Fixes #669.

To test: run in local development, there should be no pathPrefix `casei/` added. Then run `yarn build` and `yarn serve` to confirm that the pathPrefix is added and the links to internal campaign pages from the campaign timeline on the homepage work.