### PR TITLE
Make CASEI mobile-friendly

### DIFF
--- a/src/components/__tests__/__snapshots__/chip.test.js.snap
+++ b/src/components/__tests__/__snapshots__/chip.test.js.snap
@@ -21,9 +21,9 @@ exports[`Chip renders with action 1`] = `
       role="img"
     >
       <svg
-        height="12px"
+        height="16"
         viewBox="0 0 16 16"
-        width="12px"
+        width="16"
         xmlns="http://www.w3.org/2000/svg"
       >
         <polygon

--- a/src/components/__tests__/__snapshots__/chip.test.js.snap
+++ b/src/components/__tests__/__snapshots__/chip.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Chip renders with action 1`] = `
 <div
-  className="chip___StyledDiv-sc-4ga8fx-0 hrdWGh"
+  className="chip___StyledDiv-sc-4ga8fx-0 cqOzva"
   data-cy="filter-chip"
 >
   <small
@@ -11,13 +11,14 @@ exports[`Chip renders with action 1`] = `
     Weather
   </small>
   <button
-    className="button__Clickable-sc-1yw7vig-0 button___StyledClickable2-sc-1yw7vig-1 fRqvWm kXXfwm"
+    className="button__Clickable-sc-1yw7vig-0 button___StyledClickable2-sc-1yw7vig-1 fRqvWm jFCEpa"
     data-cy="remove-filter"
     onClick={[Function]}
     type="button"
   >
     <span
       aria-label="remove-filter-icon"
+      className="button___StyledSpan-sc-1yw7vig-3 lnRQLV"
       role="img"
     >
       <svg
@@ -38,7 +39,7 @@ exports[`Chip renders with action 1`] = `
 
 exports[`Chip renders without action 1`] = `
 <div
-  className="chip___StyledDiv-sc-4ga8fx-0 hrdWGh"
+  className="chip___StyledDiv-sc-4ga8fx-0 cqOzva"
   data-cy="filter-chip"
 >
   <small

--- a/src/components/__tests__/__snapshots__/data-section.test.js.snap
+++ b/src/components/__tests__/__snapshots__/data-section.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Data Section matches snapshot 1`] = `
 <section
-  className="section__Container-sc-1oozlr5-0 bIfvkW"
+  className="section__Container-sc-1oozlr5-0 fOmBFm"
   data-cy="data-section"
   mode="darkTheme"
 >
@@ -42,7 +42,7 @@ exports[`Data Section matches snapshot 1`] = `
       className="data-section___StyledDiv-sc-11szotn-0 qHvyW"
     >
       <div
-        className="filter-box___StyledDiv-sc-1n4l7nk-0 koGaSP"
+        className="filter-box___StyledDiv-sc-1n4l7nk-0 kWcCTh"
       >
         <span
           id="Campaigns"
@@ -93,7 +93,7 @@ exports[`Data Section matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="filter-box___StyledDiv-sc-1n4l7nk-0 koGaSP"
+        className="filter-box___StyledDiv-sc-1n4l7nk-0 kWcCTh"
       >
         <span
           id="Platforms"
@@ -238,7 +238,9 @@ exports[`Data Section matches snapshot 1`] = `
                 fill="#aac9ff"
               />
             </svg>
-            <span>
+            <span
+              className="external-link___StyledSpan-sc-3ezy1s-1 gYHqzm"
+            >
               10.5067/Airborne/CAMP2Ex_Aerosol_AircraftRemoteSensing_P3_Data_1
             </span>
           </a>

--- a/src/components/__tests__/__snapshots__/data-section.test.js.snap
+++ b/src/components/__tests__/__snapshots__/data-section.test.js.snap
@@ -11,7 +11,7 @@ exports[`Data Section matches snapshot 1`] = `
     id="data"
   />
   <div
-    className="section-header___StyledDiv-sc-1i4pe2i-0 SXaMi"
+    className="section-header___StyledDiv-sc-1i4pe2i-0 cVNCrb"
     data-cy="data-section-header"
   >
     <a
@@ -23,7 +23,7 @@ exports[`Data Section matches snapshot 1`] = `
     </a>
   </div>
   <div
-    className="section__SectionContent-sc-1oozlr5-2 ivTKjv"
+    className="section__SectionContent-sc-1oozlr5-2 fHLdbu"
     mode="darkTheme"
   >
     <p>
@@ -145,10 +145,10 @@ exports[`Data Section matches snapshot 1`] = `
       </div>
     </div>
     <div
-      className="data-section___StyledDiv2-sc-11szotn-1 cOIOPW"
+      className="data-section___StyledDiv2-sc-11szotn-1 HIsGX"
     >
       <div
-        className="data-section___StyledDiv3-sc-11szotn-2 KRmSO"
+        className="data-section___StyledDiv3-sc-11szotn-2 kYcAOi"
         data-cy="data-product"
       >
         <div>
@@ -200,7 +200,7 @@ exports[`Data Section matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="data-section___StyledDiv3-sc-11szotn-2 KRmSO"
+        className="data-section___StyledDiv3-sc-11szotn-2 kYcAOi"
         data-cy="data-product"
       >
         <div>
@@ -211,7 +211,7 @@ exports[`Data Section matches snapshot 1`] = `
             CAMP2Ex P-3 Remotely Sensed Aerosol Data
           </label>
           <a
-            className="external-link___StyledA-sc-3ezy1s-0 iQSFnp"
+            className="external-link___StyledA-sc-3ezy1s-0 cuaQiH"
             data-cy="doi-link"
             href="http://dx.doi.org/10.5067/Airborne/CAMP2Ex_Aerosol_AircraftRemoteSensing_P3_Data_1"
             rel="noopener noreferrer"
@@ -283,7 +283,7 @@ exports[`Data Section matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="data-section___StyledDiv3-sc-11szotn-2 KRmSO"
+        className="data-section___StyledDiv3-sc-11szotn-2 kYcAOi"
         data-cy="data-product"
       >
         <div>
@@ -335,7 +335,7 @@ exports[`Data Section matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="data-section___StyledDiv3-sc-11szotn-2 KRmSO"
+        className="data-section___StyledDiv3-sc-11szotn-2 kYcAOi"
         data-cy="data-product"
       >
         <div>
@@ -387,7 +387,7 @@ exports[`Data Section matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="data-section___StyledDiv3-sc-11szotn-2 KRmSO"
+        className="data-section___StyledDiv3-sc-11szotn-2 kYcAOi"
         data-cy="data-product"
       >
         <div>

--- a/src/components/__tests__/__snapshots__/footer.test.js.snap
+++ b/src/components/__tests__/__snapshots__/footer.test.js.snap
@@ -143,7 +143,9 @@ exports[`Footer renders correctly 1`] = `
                 fill="#aac9ff"
               />
             </svg>
-            <span>
+            <span
+              className="external-link___StyledSpan-sc-3ezy1s-1 gYHqzm"
+            >
               API Documentation
             </span>
           </a>
@@ -190,7 +192,9 @@ exports[`Footer renders correctly 1`] = `
                 fill="#aac9ff"
               />
             </svg>
-            <span>
+            <span
+              className="external-link___StyledSpan-sc-3ezy1s-1 gYHqzm"
+            >
               ADMG Website
             </span>
           </a>
@@ -224,7 +228,9 @@ exports[`Footer renders correctly 1`] = `
                 fill="#aac9ff"
               />
             </svg>
-            <span>
+            <span
+              className="external-link___StyledSpan-sc-3ezy1s-1 gYHqzm"
+            >
               IMPACT Website
             </span>
           </a>
@@ -303,7 +309,9 @@ exports[`Footer renders correctly 1`] = `
           fill="#aac9ff"
         />
       </svg>
-      <span>
+      <span
+        className="external-link___StyledSpan-sc-3ezy1s-1 gYHqzm"
+      >
         Development Seed
       </span>
     </a>

--- a/src/components/__tests__/__snapshots__/footer.test.js.snap
+++ b/src/components/__tests__/__snapshots__/footer.test.js.snap
@@ -2,17 +2,15 @@
 
 exports[`Footer renders correctly 1`] = `
 <footer
-  className="footer___StyledFooter-sc-p4lrvs-2 gvKLaO"
+  className="footer__PageFooter-sc-p4lrvs-0 iGQidj"
   data-cy="page-footer"
 >
   <div
-    className="footer___StyledDiv-sc-p4lrvs-3 irzJlc"
+    className="footer__PageFooterInner-sc-p4lrvs-1 ekVidU"
   >
-    <div
-      className="footer___StyledDiv2-sc-p4lrvs-4 fvMgqH"
-    >
+    <div>
       <div
-        className="footer___StyledDiv3-sc-p4lrvs-5 iHlXaS"
+        className="footer___StyledDiv-sc-p4lrvs-4 iAhPYw"
         data-cy="footer-title"
       >
         NASA | CASEI
@@ -27,16 +25,15 @@ exports[`Footer renders correctly 1`] = `
       </p>
     </div>
     <div
-      className="footer___StyledDiv4-sc-p4lrvs-6 fEgwOa"
       data-cy="footer-explore"
     >
       <p
-        className="footer__Headline-sc-p4lrvs-1 huPSJz"
+        className="footer__Headline-sc-p4lrvs-3 fAfnvh"
       >
         Explore
       </p>
       <ul
-        className="footer__Ul-sc-p4lrvs-0 gJnPLs"
+        className="footer__FooterSectionNavList-sc-p4lrvs-2 fWDbTw"
       >
         <li>
           <a
@@ -63,7 +60,7 @@ exports[`Footer renders correctly 1`] = `
           </a>
         </li>
         <li
-          className="footer___StyledLi-sc-p4lrvs-7 cLywhE"
+          className="footer___StyledLi-sc-p4lrvs-5 cOBauy"
         >
           <a
             data-cy="footer-coming-soon-link"
@@ -74,17 +71,14 @@ exports[`Footer renders correctly 1`] = `
         </li>
       </ul>
     </div>
-    <div
-      className="footer___StyledDiv5-sc-p4lrvs-8 dlarCn"
-      data-cy="footer-resources"
-    >
+    <div>
       <p
-        className="footer__Headline-sc-p4lrvs-1 huPSJz"
+        className="footer__Headline-sc-p4lrvs-3 fAfnvh"
       >
         Resources
       </p>
       <ul
-        className="footer__Ul-sc-p4lrvs-0 gJnPLs"
+        className="footer__FooterSectionNavList-sc-p4lrvs-2 fWDbTw"
       >
         <li>
           <a
@@ -96,16 +90,15 @@ exports[`Footer renders correctly 1`] = `
       </ul>
     </div>
     <div
-      className="footer___StyledDiv6-sc-p4lrvs-9 kvWjsj"
       data-cy="footer-quick-links"
     >
       <p
-        className="footer__Headline-sc-p4lrvs-1 huPSJz"
+        className="footer__Headline-sc-p4lrvs-3 fAfnvh"
       >
         Quick Links
       </p>
       <ul
-        className="footer__Ul-sc-p4lrvs-0 gJnPLs"
+        className="footer__FooterSectionNavList-sc-p4lrvs-2 fWDbTw"
       >
         <li>
           <a
@@ -123,7 +116,7 @@ exports[`Footer renders correctly 1`] = `
         </li>
         <li>
           <a
-            className="external-link___StyledA-sc-3ezy1s-0 iQSFnp"
+            className="external-link___StyledA-sc-3ezy1s-0 cuaQiH"
             data-cy="api documentation-link"
             href="https://nasa-impact.github.io/admg-backend/documentation/api_doc.html"
             rel="noopener noreferrer"
@@ -158,20 +151,19 @@ exports[`Footer renders correctly 1`] = `
       </ul>
     </div>
     <div
-      className="footer___StyledDiv7-sc-p4lrvs-10 egifOX"
       data-cy="footer-organizations"
     >
       <p
-        className="footer__Headline-sc-p4lrvs-1 huPSJz"
+        className="footer__Headline-sc-p4lrvs-3 fAfnvh"
       >
         Organizations
       </p>
       <ul
-        className="footer__Ul-sc-p4lrvs-0 gJnPLs"
+        className="footer__FooterSectionNavList-sc-p4lrvs-2 fWDbTw"
       >
         <li>
           <a
-            className="external-link___StyledA-sc-3ezy1s-0 iQSFnp"
+            className="external-link___StyledA-sc-3ezy1s-0 cuaQiH"
             data-cy="admg-website-link"
             href="https://earthdata.nasa.gov/esds/impact/admg"
             rel="noopener noreferrer"
@@ -205,7 +197,7 @@ exports[`Footer renders correctly 1`] = `
         </li>
         <li>
           <a
-            className="external-link___StyledA-sc-3ezy1s-0 iQSFnp"
+            className="external-link___StyledA-sc-3ezy1s-0 cuaQiH"
             data-cy="impact-website-link"
             href="https://earthdata.nasa.gov/esds/impact"
             rel="noopener noreferrer"
@@ -239,14 +231,12 @@ exports[`Footer renders correctly 1`] = `
         </li>
       </ul>
     </div>
-    <hr
-      className="footer___StyledHr-sc-p4lrvs-11 eoPdla"
-    />
+    <hr />
     <div
-      className="footer___StyledDiv8-sc-p4lrvs-12 ssMNC"
+      className="footer___StyledDiv2-sc-p4lrvs-6 grPBXa"
     >
       <div
-        className="footer___StyledDiv9-sc-p4lrvs-13 fIhhKf"
+        className="footer___StyledDiv3-sc-p4lrvs-7 iuXYQY"
       >
         <a
           aria-label="Visit nasa.gov (opens in a new window)"
@@ -268,7 +258,7 @@ exports[`Footer renders correctly 1`] = `
             NASA Official:
              
             <span
-              className="footer___StyledSpan-sc-p4lrvs-14 dznhzw"
+              className="footer___StyledSpan-sc-p4lrvs-8 kOgjsV"
             >
               Rahul Ramachandran
             </span>
@@ -278,7 +268,7 @@ exports[`Footer renders correctly 1`] = `
     </div>
   </div>
   <div
-    className="footer___StyledDiv10-sc-p4lrvs-15 hmTsNQ"
+    className="footer___StyledDiv4-sc-p4lrvs-9 imNSLA"
     data-cy="footer-credit-devseed"
   >
     © 
@@ -286,7 +276,7 @@ exports[`Footer renders correctly 1`] = `
     , Built by
      
     <a
-      className="external-link___StyledA-sc-3ezy1s-0 iQSFnp"
+      className="external-link___StyledA-sc-3ezy1s-0 cuaQiH"
       data-cy="devseed-website-link"
       href="https://www.developmentseed.org"
       rel="noopener noreferrer"

--- a/src/components/__tests__/__snapshots__/header.test.js.snap
+++ b/src/components/__tests__/__snapshots__/header.test.js.snap
@@ -2,29 +2,31 @@
 
 exports[`Header renders correctly 1`] = `
 <div
-  className="sticky-banner___StyledDiv-sc-e0ldth-0 gjXAxl"
+  className="sticky-banner___StyledDiv-sc-e0ldth-0 fAmbOa"
 >
   <header
-    className="header___StyledHeader-sc-4sefiz-0 eymLSC"
+    className="header__PageHeaderSelf-sc-4sefiz-0 esItOh"
     id="main-header"
+    mode="lightTheme"
   >
     <div
-      className="header___StyledDiv-sc-4sefiz-1 hgzXFp"
+      className="header__PageHeaderInner-sc-4sefiz-1 jolyZD"
     >
       <div
-        className="header___StyledDiv2-sc-4sefiz-2 hkPJce"
+        className="header___StyledDiv-sc-4sefiz-6 gZfonL"
       >
         <a
           aria-label="Visit nasa.gov (opens in a new window)"
+          className="header__BrandImageLink-sc-4sefiz-3 eImqit"
           href="https://www.nasa.gov"
           rel="noopener noreferrer"
           target="_blank"
         />
         <div
-          className="header___StyledDiv3-sc-4sefiz-3 xYXsp"
+          className="header___StyledDiv2-sc-4sefiz-7 hZZACY"
         />
         <a
-          className="header___StyledLink-sc-4sefiz-4 zwKr"
+          className="header___StyledLink-sc-4sefiz-8 fzkXbZ"
           href="/"
         >
           <svg
@@ -57,14 +59,40 @@ exports[`Header renders correctly 1`] = `
             </g>
           </svg>
           <div
-            className="header___StyledDiv4-sc-4sefiz-5 jQxBae"
+            className="header___StyledDiv3-sc-4sefiz-9 dgEIeO"
           >
             Shortname from props
           </div>
         </a>
       </div>
       <div
-        className="header___StyledDiv5-sc-4sefiz-6 iMBbkb"
+        className="header__PageNavToggleWrapper-sc-4sefiz-4 inGjsJ"
+      >
+        <button
+          className="button__Clickable-sc-1yw7vig-0 button___StyledClickable-sc-1yw7vig-2 fRqvWm bvKEjn"
+          onClick={[Function]}
+        >
+          <svg
+            fill="currentColor"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M432 256c0 17.7-14.3 32-32 32L48 288c-17.7 0-32-14.3-32-32s14.3-32 32-32l352 0c17.7 0 32 14.3 32 32z"
+              fill="#262a31"
+            />
+            <path
+              d="M1,9h14V7H1V9z M1,14h14v-2H1V14z M1,2v2h14V2H1z"
+            />
+          </svg>
+        </button>
+      </div>
+      <nav
+        className="header__PageNavWrapper-sc-4sefiz-2 ca-dZgN"
+        mode="lightTheme"
+        role="navigation"
       />
     </div>
   </header>

--- a/src/components/__tests__/__snapshots__/header.test.js.snap
+++ b/src/components/__tests__/__snapshots__/header.test.js.snap
@@ -26,7 +26,7 @@ exports[`Header renders correctly 1`] = `
           className="header___StyledDiv2-sc-4sefiz-7 hZZACY"
         />
         <a
-          className="header___StyledLink-sc-4sefiz-8 fzkXbZ"
+          className="header___StyledLink-sc-4sefiz-8 itVwCK"
           href="/"
         >
           <svg

--- a/src/components/__tests__/__snapshots__/hero.test.js.snap
+++ b/src/components/__tests__/__snapshots__/hero.test.js.snap
@@ -6,24 +6,26 @@ exports[`Header renders correctly 1`] = `
   data-cy="test-hero"
 >
   <div
-    className="hero___StyledDiv-sc-qftwzr-4 XtAsv"
+    className="hero__HeroContentWrapper-sc-qftwzr-1 dEHppu"
   >
     <div
-      className="hero___StyledDiv2-sc-qftwzr-5 kAspDW"
+      className="hero___StyledDiv-sc-qftwzr-6 hubuVj"
     >
       <p
-        className="hero___StyledP-sc-qftwzr-7 yHaZP"
+        className="hero___StyledP-sc-qftwzr-8 hbWiGQ"
       >
         Instrument
       </p>
-      <h1>
+      <h1
+        className="hero__HeroTitle-sc-qftwzr-2 ivhDcq"
+      >
         2D-C/P
          
         2D-C/P Hydrometeor Imaging Probe
       </h1>
     </div>
     <div
-      className="hero___StyledDiv3-sc-qftwzr-8 eeIULr"
+      className="hero___StyledDiv2-sc-qftwzr-9 eJqIxP"
     >
       <p>
         The 2DC probe records images of hydrometeors...
@@ -37,7 +39,7 @@ exports[`Header renders correctly 1`] = `
           Data Shortcut
         </span>
         <div
-          className="typeahead-box___StyledDiv2-sc-1kp6jj-2 gRJNDe"
+          className="typeahead-box___StyledDiv2-sc-1kp6jj-2 byvdUB"
         >
           <input
             className="typeahead-box___StyledInput-sc-1kp6jj-3 ddjRvz"
@@ -91,24 +93,26 @@ exports[`Header renders with adjust ratios 1`] = `
   data-cy="undefined-hero"
 >
   <div
-    className="hero___StyledDiv-sc-qftwzr-4 fnFsnz"
+    className="hero__HeroContentWrapper-sc-qftwzr-1 ehQfhu"
   >
     <div
-      className="hero___StyledDiv2-sc-qftwzr-5 kAspDW"
+      className="hero___StyledDiv-sc-qftwzr-6 hubuVj"
     >
       <p
-        className="hero___StyledP-sc-qftwzr-7 yHaZP"
+        className="hero___StyledP-sc-qftwzr-8 hbWiGQ"
       >
         Instrument
       </p>
-      <h1>
+      <h1
+        className="hero__HeroTitle-sc-qftwzr-2 ivhDcq"
+      >
         2D-C/P
          
         2D-C/P Hydrometeor Imaging Probe
       </h1>
     </div>
     <div
-      className="hero___StyledDiv3-sc-qftwzr-8 eeIULr"
+      className="hero___StyledDiv2-sc-qftwzr-9 eJqIxP"
     >
       <p>
         The 2DC probe records images of hydrometeors...
@@ -122,7 +126,7 @@ exports[`Header renders with adjust ratios 1`] = `
           Data Shortcut
         </span>
         <div
-          className="typeahead-box___StyledDiv2-sc-1kp6jj-2 gRJNDe"
+          className="typeahead-box___StyledDiv2-sc-1kp6jj-2 byvdUB"
         >
           <input
             className="typeahead-box___StyledInput-sc-1kp6jj-3 ddjRvz"

--- a/src/components/button.js
+++ b/src/components/button.js
@@ -15,7 +15,10 @@ const Clickable = styled.button`
 `
 
 const Button = React.forwardRef(
-  ({ children, action, mode = NEGATIVE, isSecondary, as }, ref) => {
+  (
+    { children, action, mode = NEGATIVE, isSecondary, as, iconOnly, noBorder },
+    ref
+  ) => {
     // flip mode for primary buttons
     const overrideMode = isSecondary
       ? mode
@@ -30,14 +33,20 @@ const Button = React.forwardRef(
         onClick={action}
         css={`
            {
+            display: inline-flex;
+            flex-flow: row nowrap;
+            justify-content: center;
+            align-items: center;
             user-select: none;
             color: ${colors[overrideMode].text};
             text-align: center;
             vertical-align: middle;
-            padding: 0.25rem 0.75rem;
+            padding: ${iconOnly ? "0.5rem" : "0.25rem 0.75rem"};
             background: none;
             text-shadow: none;
-            border: 1px solid ${colors[overrideMode].text};
+            border: ${noBorder
+              ? "none"
+              : `1px solid ${colors[overrideMode].text}`};
             cursor: pointer;
             background-color: ${isSecondary
               ? colors[mode].background
@@ -58,6 +67,8 @@ Button.propTypes = {
   action: PropTypes.func,
   mode: PropTypes.oneOf([POSITIVE, NEGATIVE]),
   isSecondary: PropTypes.bool,
+  iconOnly: PropTypes.bool,
+  noBorder: PropTypes.bool,
   as: PropTypes.string,
 }
 

--- a/src/components/button.js
+++ b/src/components/button.js
@@ -77,9 +77,9 @@ Button.displayName = "Button"
 
 export default Button
 
-export const IconButton = ({ id, icon, action }) => (
+export const IconButton = ({ id, icon, action, type }) => (
   <Clickable
-    type="button"
+    type={type || "button"}
     onClick={action}
     css={`
       background: none;
@@ -88,11 +88,17 @@ export const IconButton = ({ id, icon, action }) => (
       cursor: pointer;
       color: ${colors[NEGATIVE].text};
       vertical-align: middle;
-      margin-left: 0.5rem;
     `}
     data-cy={id}
   >
-    <span role="img" aria-label={`${id}-icon`}>
+    <span
+      role="img"
+      aria-label={`${id}-icon`}
+      css={`
+        display: flex;
+        align-content: center;
+      `}
+    >
       {icon}
     </span>
   </Clickable>
@@ -102,4 +108,5 @@ IconButton.propTypes = {
   id: PropTypes.string.isRequired,
   action: PropTypes.func,
   icon: PropTypes.node.isRequired,
+  type: PropTypes.string,
 }

--- a/src/components/carousel-accordion-combo.js
+++ b/src/components/carousel-accordion-combo.js
@@ -60,25 +60,6 @@ export default function CarouselAccordionCombo({
               prevButtonText: `⦉`,
               prevButtonStyle: controlButtonLRStyle,
             }}
-            getControlsContainerStyles={key => {
-              switch (key) {
-                case "BottomCenter":
-                  return {
-                    bottom: "-42px",
-                  }
-                case "CenterLeft":
-                  return {
-                    marginLeft: "-50px",
-                  }
-                case "CenterRight":
-                  return {
-                    marginRight: "-50px",
-                  }
-                default:
-                  // will apply all other keys
-                  return
-              }
-            }}
             heightMode="max"
           >
             {carouselList.map((carouselItem, index) => (

--- a/src/components/chip.js
+++ b/src/components/chip.js
@@ -25,7 +25,7 @@ const Chip = ({
       color: ${colors[NEGATIVE].text};
       border-radius: ${shape.rounded};
       padding: 0.25rem 0.5rem;
-      margin: ${isInline ? 0 : "0.25rem 0.5rem"};
+      gap: 0.5rem;
     `}
     data-cy={`${id}-chip`}
   >

--- a/src/components/data-section.js
+++ b/src/components/data-section.js
@@ -7,7 +7,7 @@ import ExternalLink from "./external-link"
 import Label from "./label"
 import { NEGATIVE } from "../utils/constants"
 import { selector, uniqueElementsById, doiFilter } from "../utils/filter-utils"
-import { colors } from "../theme"
+import { colors, breakpoints } from "../theme"
 import FilterChips from "./filter/filter-chips"
 import FilterBox from "./filter/filter-box"
 import Chip from "./chip"
@@ -138,8 +138,11 @@ const DataSection = ({ id, dois, filterBy, category }) => {
                 display: flex;
                 flex-direction: column;
                 max-height: 35rem;
-                overflow: auto;
                 gap: 1rem;
+                overflow-y: scroll;
+                @media screen and (min-width: ${breakpoints["sm"]}) {
+                  overflow: auto;
+                }
               `}
             >
               {filteredDois.map(doi => {
@@ -149,9 +152,14 @@ const DataSection = ({ id, dois, filterBy, category }) => {
                     css={`
                       display: grid;
                       gap: 1rem;
-                      grid-template-columns: 1fr 1fr;
+                      grid-template-columns: minmax(0, 1fr);
+                      grid-template-rows: auto 1fr;
                       background-color: ${colors[NEGATIVE].background};
                       padding: 1.5rem;
+                      @media screen and (min-width: ${breakpoints["sm"]}) {
+                        grid-template-columns: 1fr 1fr;
+                        grid-template-rows: 1fr;
+                      }
                     `}
                     data-cy="data-product"
                   >

--- a/src/components/explore/explore-menu.js
+++ b/src/components/explore/explore-menu.js
@@ -4,7 +4,7 @@ import styled from "styled-components"
 import { Link } from "gatsby"
 
 import { NEGATIVE } from "../../utils/constants"
-import { colors } from "../../theme"
+import { colors, breakpoints } from "../../theme"
 
 const TabButton = styled(Link)`
   /* remove default button style */
@@ -100,11 +100,17 @@ const ExploreMenu = ({ selectedCategory, filteredCount }) => (
        {
         display: flex;
         flex-direction: row;
-        gap: 2rem;
+        flex-wrap: wrap;
+        gap: 0rem;
         margin-top: 2rem;
         list-style: none;
-        align-items: center;
+        align-items: flex-start;
         justify-content: center;
+        @media screen and (min-width: ${breakpoints["sm"]}) {
+          align-items: center;
+          justify-content: center;
+          flex-direction: row;
+        }
       }
     `}
     data-cy="tabbar"

--- a/src/components/explore/explore-menu.js
+++ b/src/components/explore/explore-menu.js
@@ -110,6 +110,7 @@ const ExploreMenu = ({ selectedCategory, filteredCount }) => (
           align-items: center;
           justify-content: center;
           flex-direction: row;
+          gap: 2rem;
         }
       }
     `}

--- a/src/components/explore/explore-tools.js
+++ b/src/components/explore/explore-tools.js
@@ -48,6 +48,7 @@ const ExploreTools = React.forwardRef(
               display: flex;
               align-items: center;
               gap: 0.55rem;
+              flex-grow: 1;
             `}
             data-cy="main-filter-label"
           >

--- a/src/components/explore/filter-by-textinput.js
+++ b/src/components/explore/filter-by-textinput.js
@@ -4,7 +4,8 @@ import { useDebouncedCallback } from "use-debounce"
 
 import { CloseIcon, SearchIcon } from "../../icons"
 import { NEGATIVE } from "../../utils/constants"
-import { colors } from "../../theme"
+import { colors, breakpoints } from "../../theme"
+import { IconButton } from "../button"
 
 const FilterByTextInput = React.forwardRef(
   ({ setSearchResult, category }, ref) => {
@@ -22,26 +23,23 @@ const FilterByTextInput = React.forwardRef(
         css={`
           border: 1px solid ${colors[NEGATIVE].text};
           padding: 0.25rem;
-          flex-grow: 1;
-          width: 30rem;
+          flex: 1;
+          max-width: 100%;
+          flex-basis: 100%;
           display: flex;
           align-content: stretch;
+          align-items: center;
+          @media screen and (min-width: ${breakpoints["sm"]}) {
+            width: 30rem;
+            flex-basis: inherit;
+          }
         `}
       >
-        <button
-          css={`
-            border: none;
-            flex-grow: 0;
-            background: transparent;
-            color: ${colors[NEGATIVE].text};
-            vertical-align: middle;
-          `}
+        <IconButton
           data-cy="submit"
-        >
-          <span role="img" aria-label="Magnifying glass icon">
-            <SearchIcon color={colors[NEGATIVE].text} />
-          </span>
-        </button>
+          icon={<SearchIcon color={colors[NEGATIVE].text} />}
+          type="submit"
+        />
         <input
           autoComplete="off"
           data-cy="explore-input"
@@ -65,22 +63,13 @@ const FilterByTextInput = React.forwardRef(
           ref={ref}
         />
         {ref.current?.value && (
-          <button
+          <IconButton
             type="reset"
-            onClick={() => setInputsize(50)}
-            css={`
-              border: none;
-              flex-grow: 0;
-              background: transparent;
-              color: ${colors[NEGATIVE].text};
-              vertical-align: middle;
-            `}
+            action={() => setInputsize(50)}
             data-cy="reset"
-          >
-            <span role="img" aria-label="X icon">
-              <CloseIcon color={colors[NEGATIVE].text} />
-            </span>
-          </button>
+            icon={<CloseIcon color={colors[NEGATIVE].text} />}
+            aria-label="X icon"
+          />
         )}
       </div>
     )

--- a/src/components/external-link.js
+++ b/src/components/external-link.js
@@ -31,7 +31,13 @@ export default function ExternalLink({
       data-cy={`${id}-link`}
     >
       <ExternalLinkIcon color={colors[mode].linkText} />
-      <span>{label || children}</span>
+      <span
+        css={`
+          overflow-wrap: anywhere;
+        `}
+      >
+        {label || children}
+      </span>
     </a>
   )
 }

--- a/src/components/external-link.js
+++ b/src/components/external-link.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types"
 
 import { POSITIVE, NEGATIVE } from "../utils/constants"
 import { PropTypeIsUrl } from "../utils/helpers"
-import { colors } from "../theme"
+import { colors, breakpoints } from "../theme"
 import { ExternalLinkIcon } from "../icons"
 
 export default function ExternalLink({
@@ -24,6 +24,9 @@ export default function ExternalLink({
         flex-flow: row nowrap;
         gap: 0.25rem;
         align-items: baseline;
+        @media screen and (min-width: ${breakpoints["sm"]}) {
+          flex-flow: row wrap;
+        }
       `}
       data-cy={`${id}-link`}
     >

--- a/src/components/filter/filter-box.js
+++ b/src/components/filter/filter-box.js
@@ -12,7 +12,7 @@ import VisuallyHidden from "@reach/visually-hidden"
 import { IconButton } from "../button"
 import { CloseIcon } from "../../icons"
 import { NEGATIVE } from "../../utils/constants"
-import { colors, shape } from "../../theme"
+import { colors, shape, breakpoints } from "../../theme"
 
 export default function FilterBox({
   filterOptions,
@@ -32,7 +32,10 @@ export default function FilterBox({
   return (
     <div
       css={`
-        margin-right: 2rem;
+        margin-right: 0.5rem;
+        @media screen and (min-width: ${breakpoints["sm"]}) {
+          margin-right: 2rem;
+        }
       `}
     >
       <VisuallyHidden id={filterName}>{filterName}</VisuallyHidden>

--- a/src/components/filter/filter-chips.js
+++ b/src/components/filter/filter-chips.js
@@ -2,7 +2,7 @@ import React from "react"
 import PropTypes from "prop-types"
 
 import { NEGATIVE } from "../../utils/constants"
-import { colors } from "../../theme"
+import { colors, breakpoints } from "../../theme"
 
 export default function FilterChips({ clearFilters, children }) {
   return (
@@ -10,8 +10,12 @@ export default function FilterChips({ clearFilters, children }) {
       css={`
         display: flex;
         flex-wrap: wrap;
-        margin: 2rem 0;
+        gap: 0.25rem 0.5rem;
         align-items: center;
+        @media screen and (min-width: ${breakpoints["sm"]}) {
+          gap: 0.5rem 1rem;
+        }
+        margin: 0.5rem 0;
       `}
     >
       Active filters:

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -4,46 +4,63 @@ import { Link } from "gatsby"
 import { StaticImage } from "gatsby-plugin-image"
 import styled from "styled-components"
 import { NEGATIVE } from "../utils/constants"
-import { colors, layout } from "../theme"
+import { colors, layout, breakpoints } from "../theme"
 import ExternalLink from "./external-link"
 import { API_DOCUMENTATION_URL } from "../utils/constants"
 
-const Ul = styled.ul`
+const PageFooter = styled.footer`
+  margin-top: 5rem;
+  padding-bottom: 2rem;
+  background-color: ${colors[NEGATIVE].background};
+`
+const PageFooterInner = styled.div`
+  display: flex;
+  flex-flow: column;
+  gap: 1rem;
+  flex-wrap: nowrap;
+  margin: 5rem auto 2rem;
+  max-width: ${layout.maxWidth};
+  padding: 2rem ${layout.smallPageMargin};
+  @media screen and (min-width: ${breakpoints["sm"]}) {
+    padding: 2rem ${layout.pageMargin};
+    flex-shrink: 0;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 1rem 3rem;
+  }
+  & > div {
+    flex: 1;
+    min-width: fit-content;
+    &:first-child {
+      flex: 2;
+      padding-right: 2rem;
+      min-width: 19rem;
+    }
+  }
+  & > hr {
+    width: 100%;
+    background-color: rgba(255, 255, 255, 0.2);
+  }
+`
+const FooterSectionNavList = styled.ul`
   list-style: none;
   margin: 0;
 `
 const Headline = styled.p`
-  margin: 0 0 1.5rem 0;
   font-weight: bold;
   line-height: 3rem;
+  margin: 0;
+  @media screen and (min-width: ${breakpoints["sm"]}) {
+    margin-bottom: 1.5rem;
+  }
 `
 
-const Footer = ({ shortname }) => {
+const Footer = ({ shortname, isMediumDown }) => {
+  console.log(isMediumDown)
   return (
-    <footer
-      css={`
-        margin-top: 5rem;
-        padding-bottom: 2rem;
-        background-color: ${colors[NEGATIVE].background};
-      `}
-      data-cy="page-footer"
-    >
-      <div
-        css={`
-          margin: 5rem auto 2rem;
-          max-width: ${layout.maxWidth};
-          padding: 2rem ${layout.pageMargin};
-          flex-shrink: 0;
-          display: grid;
-          gap: 1rem;
-          grid-template-columns: repeat(12, 1fr);
-        `}
-      >
-        <div
-          css={`
-            grid-column: 1 / span 3;
-          `}
-        >
+    <PageFooter data-cy="page-footer">
+      <PageFooterInner>
+        <div>
           <div
             css={`
               text-transform: uppercase;
@@ -64,14 +81,9 @@ const Footer = ({ shortname }) => {
           </p>
         </div>
 
-        <div
-          css={`
-            grid-column: 5 / span 2;
-          `}
-          data-cy="footer-explore"
-        >
+        <div data-cy="footer-explore">
           <Headline>Explore</Headline>
-          <Ul>
+          <FooterSectionNavList>
             <li>
               <Link to="/explore/campaigns" data-cy="footer-campaigns-link">
                 Campaigns
@@ -98,31 +110,21 @@ const Footer = ({ shortname }) => {
                 Coming Soon
               </Link>
             </li>
-          </Ul>
+          </FooterSectionNavList>
         </div>
 
-        <div
-          css={`
-            grid-column: 7 / span 2;
-          `}
-          data-cy="footer-resources"
-        >
+        <div>
           <Headline>Resources</Headline>
-          <Ul>
+          <FooterSectionNavList>
             <li>
               <Link to="/glossary/">Glossary</Link>
             </li>
-          </Ul>
+          </FooterSectionNavList>
         </div>
 
-        <div
-          css={`
-            grid-column: 9 / span 2;
-          `}
-          data-cy="footer-quick-links"
-        >
+        <div data-cy="footer-quick-links">
           <Headline>Quick Links</Headline>
-          <Ul>
+          <FooterSectionNavList>
             <li>
               <Link to="/about/">About</Link>
             </li>
@@ -140,17 +142,12 @@ const Footer = ({ shortname }) => {
                 API Documentation
               </ExternalLink>
             </li>
-          </Ul>
+          </FooterSectionNavList>
         </div>
 
-        <div
-          css={`
-            grid-column: 11 / span 2;
-          `}
-          data-cy="footer-organizations"
-        >
+        <div data-cy="footer-organizations">
           <Headline>Organizations</Headline>
-          <Ul>
+          <FooterSectionNavList>
             <li>
               <ExternalLink
                 label="ADMG Website"
@@ -165,19 +162,13 @@ const Footer = ({ shortname }) => {
                 id="impact-website"
               />
             </li>
-          </Ul>
+          </FooterSectionNavList>
         </div>
 
-        <hr
-          css={`
-            grid-column: 1 / span 12;
-            background-color: rgba(255, 255, 255, 0.2);
-          `}
-        />
+        <hr />
 
         <div
           css={`
-            grid-column: 1 / span 12;
             display: flex;
             justify-content: space-between;
           `}
@@ -220,7 +211,7 @@ const Footer = ({ shortname }) => {
             </div>
           </div>
         </div>
-      </div>
+      </PageFooterInner>
 
       <div
         css={`
@@ -236,12 +227,13 @@ const Footer = ({ shortname }) => {
         />
         .
       </div>
-    </footer>
+    </PageFooter>
   )
 }
 
 Footer.propTypes = {
   shortname: PropTypes.string.isRequired,
+  isMediumDown: PropTypes.bool,
 }
 
 export default Footer

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -55,8 +55,7 @@ const Headline = styled.p`
   }
 `
 
-const Footer = ({ shortname, isMediumDown }) => {
-  console.log(isMediumDown)
+const Footer = ({ shortname }) => {
   return (
     <PageFooter data-cy="page-footer">
       <PageFooterInner>
@@ -233,7 +232,6 @@ const Footer = ({ shortname, isMediumDown }) => {
 
 Footer.propTypes = {
   shortname: PropTypes.string.isRequired,
-  isMediumDown: PropTypes.bool,
 }
 
 export default Footer

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,15 +1,128 @@
-import React from "react"
+import React, { useState } from "react"
 import PropTypes from "prop-types"
+import styled, { css, keyframes, createGlobalStyle } from "styled-components"
 import { Link } from "gatsby"
 import { StaticImage } from "gatsby-plugin-image"
 
 import { colors, layout, breakpoints } from "../theme"
-import { CaseiLogoIcon } from "../icons"
+import { CaseiLogoIcon, CloseIcon, HamburgerIcon } from "../icons"
 import { NEGATIVE } from "../utils/constants"
 import StickyBanner from "./sticky-banner"
 import SimpleBanner from "./simple-banner"
+import Button from "./button"
 
-const Header = ({ shortname, children, mode }) => {
+const reveal = keyframes`
+0% {
+    opacity: 0;
+}
+100% {
+    opacity: 1;
+}
+`
+const PageHeaderSelf = styled.header`
+  z-index: 3;
+  background-color: ${({ mode }) => mode && colors[mode].background};
+  box-shadow: rgba(68, 63, 63, 0.08) 0px -1px 1px 0px,
+    rgba(68, 63, 63, 0.08) 0px 2px 6px 0px;
+  animation: ${reveal} 0.32s ease 0s 1;
+`
+
+const PageHeaderInner = styled.div`
+  margin: 0 auto;
+  max-width: ${layout.maxWidth};
+  padding: 0.25rem ${layout.pageMargin};
+  @media screen and (max-width: ${breakpoints["sm"]}) {
+    padding: 0.75rem ${layout.smallPageMargin};
+  }
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  position: relative;
+  z-index: 30;
+  /* Animation */
+  animation: ${reveal} 0.32s ease 0s 1;
+  &::before {
+    position: absolute;
+    z-index: 40;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 4.5rem;
+    content: "";
+    background: linear-gradient(
+      0deg,
+      rgba(255, 255, 255, 0) 75%,
+      rgba(255, 255, 255, 1) 100%
+    );
+    @media screen and (min-width: ${breakpoints["sm"]}) {
+      display: none;
+    }
+  }
+`
+const PageNavWrapper = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 100%;
+  z-index: 20;
+  display: flex;
+  flex-flow: column nowrap;
+  padding: 5rem 1rem 1rem;
+  overflow: auto;
+  pointer-events: auto;
+  background-color: ${({ mode }) => mode && colors[mode].background};
+  transform: translate(0, -100%);
+  margin: 0;
+  transition: all 0.4s ease-in-out 0s;
+  will-change: transform;
+  box-shadow: rgba(68, 63, 63, 0.08) 0px -1px 1px 0px,
+    rgba(68, 63, 63, 0.08) 0px 2px 6px 0px;
+  ${({ revealed }) =>
+    revealed &&
+    css`
+      transform: translate(0, 0);
+    `};
+  @media screen and (min-width: ${breakpoints["sm"]}) {
+    margin-left: auto;
+    position: static;
+    flex-flow: row nowrap;
+    padding: 0;
+    overflow: visible;
+    transform: translate(0, 0);
+    justify-content: space-between;
+    box-shadow: none;
+  }
+`
+const BrandImageLink = styled.a`
+  height: ${({ isMediumDown }) => (isMediumDown ? "2rem" : "78px")};
+  width: ${({ isMediumDown }) => (isMediumDown ? "2rem" : "78px")};
+`
+
+const PageNavToggleWrapper = styled.div`
+  position: relative;
+  z-index: 50;
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: flex-end;
+  @media screen and (min-width: ${breakpoints["sm"]}) {
+    display: none;
+  }
+`
+const PageNavToggle = styled(Button)``
+
+const PageNavGlobalStyle = createGlobalStyle`
+  body {
+    ${({ isActive }) =>
+      isActive &&
+      css`
+        overflow: hidden;
+      `}
+  }
+`
+
+const Header = ({ shortname, children, mode, isMediumDown }) => {
   const offsetCalculator = (scrollDirection, _, currentScroll) => {
     if (scrollDirection === "scroll-down" && currentScroll > 250) {
       return `-${document.getElementById("main-header").clientHeight}px`
@@ -17,46 +130,32 @@ const Header = ({ shortname, children, mode }) => {
       return 0
     }
   }
-
+  console.log(isMediumDown)
+  const [navRevealed, setNavRevealed] = useState(false)
   return (
-    <StickyBanner offsetCalculator={offsetCalculator}>
-      <header
-        id="main-header"
-        css={`
-          z-index: 3;
-          background-color: ${colors[mode].background};
-          box-shadow: rgba(68, 63, 63, 0.08) 0px -1px 1px 0px,
-            rgba(68, 63, 63, 0.08) 0px 2px 6px 0px;
-        `}
-      >
+    <StickyBanner
+      offsetCalculator={offsetCalculator}
+      isMediumDown={isMediumDown}
+      navRevealed={navRevealed}
+    >
+      <PageHeaderSelf id="main-header" mode={mode}>
         <SimpleBanner />
-        <div
-          css={`
-            margin: 0 auto;
-            max-width: ${layout.maxWidth};
-            padding: 0.25rem ${layout.pageMargin};
-            @media screen and (max-width: ${breakpoints["sm"]}) {
-              padding: 0.25rem ${layout.smallPageMargin};
-            }
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-          `}
-        >
+        <PageHeaderInner isMediumDown={isMediumDown}>
           <div
             css={`
               margin: 0;
               z-index: 100;
               display: flex;
               align-items: center;
-              gap: 1rem;
+              gap: ${isMediumDown ? "0.5rem" : "1rem"};
             `}
           >
-            <a
+            <BrandImageLink
               target="_blank"
               rel="noopener noreferrer"
               href="https://www.nasa.gov"
               aria-label="Visit nasa.gov (opens in a new window)"
+              isMediumDown={isMediumDown}
             >
               <StaticImage
                 src="../images/nasa-logo-web-rgb.png"
@@ -65,7 +164,7 @@ const Header = ({ shortname, children, mode }) => {
                 height={78} // make the blue circle match the svg logo of size 60
                 data-cy="nasa-logo"
               />
-            </a>
+            </BrandImageLink>
 
             <div
               css={`
@@ -80,15 +179,18 @@ const Header = ({ shortname, children, mode }) => {
               css={`
                 text-decoration: none;
                 display: grid;
-                grid-template-columns: 3rem auto;
-                column-gap: 2rem;
+                grid-template-columns: max-content auto;
+                column-gap: ${isMediumDown ? "1rem" : "2rem"};
                 align-items: center;
               `}
             >
-              <CaseiLogoIcon size="small" color={colors[mode].text} />
+              <CaseiLogoIcon
+                size={isMediumDown ? "tiny" : "small"}
+                color={colors[mode].text}
+              />
               <div
                 css={`
-                  font-size: 1.5rem;
+                  font-size: ${isMediumDown ? "1.25rem" : "1.5rem"};
                   color: ${colors[mode].text};
                 `}
               >
@@ -96,15 +198,31 @@ const Header = ({ shortname, children, mode }) => {
               </div>
             </Link>
           </div>
-          <div
-            css={`
-              display: flex;
-            `}
+          <PageNavGlobalStyle isActive={navRevealed} />
+          <PageNavToggleWrapper>
+            <PageNavToggle
+              title="Reveal/hide menu"
+              action={() => setNavRevealed(v => !v)}
+              iconOnly
+              noBorder
+            >
+              {navRevealed ? (
+                <CloseIcon size="text" color={colors[mode].text} />
+              ) : (
+                <HamburgerIcon size="text" color={colors[mode].text} />
+              )}
+            </PageNavToggle>
+          </PageNavToggleWrapper>
+          <PageNavWrapper
+            mode={mode}
+            as="nav"
+            role="navigation"
+            revealed={navRevealed}
           >
             {children}
-          </div>
-        </div>
-      </header>
+          </PageNavWrapper>
+        </PageHeaderInner>
+      </PageHeaderSelf>
     </StickyBanner>
   )
 }
@@ -113,6 +231,7 @@ Header.propTypes = {
   shortname: PropTypes.string.isRequired,
   children: PropTypes.element,
   mode: PropTypes.string.isRequired,
+  isMediumDown: PropTypes.bool.isRequired,
 }
 
 export default Header

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -180,7 +180,7 @@ const Header = ({ shortname, children, mode, isMediumDown }) => {
                 text-decoration: none;
                 display: grid;
                 grid-template-columns: max-content auto;
-                column-gap: ${isMediumDown ? "1rem" : "2rem"};
+                column-gap: ${isMediumDown ? "0.5rem" : "1rem"};
                 align-items: center;
               `}
             >

--- a/src/components/hero.js
+++ b/src/components/hero.js
@@ -5,7 +5,7 @@ import styled from "styled-components"
 import { StaticImage } from "gatsby-plugin-image"
 
 import { NEGATIVE, POSITIVE } from "../utils/constants"
-import { colors, layout } from "../theme"
+import { colors, layout, breakpoints } from "../theme"
 import DateList from "./date-list-hover"
 import { ArrowIcon } from "../icons"
 import { TypeAhead } from "../components/typeahead-box"
@@ -75,7 +75,26 @@ const Container = styled.section`
         }%, rgba(12,21,32, 0.0)${ratioInPercent + 20}%)`
       : null};
 `
+const HeroContentWrapper = styled.div`
+  grid-area: 1 / 2 / 1 / 2;
 
+  display: grid;
+  grid-template-columns: ${({ textToImageRatio }) =>
+    textToImageRatio && `${textToImageRatio[0]}fr ${textToImageRatio[1]}fr`};
+  grid-template-areas:
+    "title image"
+    "extras image";
+  grid-gap: 0.5rem;
+  padding: 0 ${layout.smallPageMargin};
+  @media screen and (min-width: ${breakpoints["sm"]}) {
+    padding: 0 ${layout.pageMargin};
+  }
+`
+const HeroTitle = styled.h1`
+  @media screen and (max-width: ${breakpoints["sm"]}) {
+    font-size: 2.875rem;
+  }
+`
 export default function Hero({
   backlink,
   tagline,
@@ -117,19 +136,7 @@ export default function Hero({
       backgroundImage={backgroundImage}
       ratioInPercent={ratioInPercent}
     >
-      <div
-        css={`
-          grid-area: 1 / 2 / 1 / 2;
-
-          display: grid;
-          grid-template-columns: ${textToImageRatio[0]}fr ${textToImageRatio[1]}fr;
-          grid-template-areas:
-            "title image"
-            "extras image";
-          grid-gap: 0.5rem;
-          padding: 0 ${layout.pageMargin};
-        `}
-      >
+      <HeroContentWrapper textToImageRatio={textToImageRatio}>
         <div
           css={`
             align-self: end;
@@ -165,7 +172,7 @@ export default function Hero({
             </p>
           )}
 
-          <h1>{title}</h1>
+          <HeroTitle>{title}</HeroTitle>
         </div>
 
         <div
@@ -190,6 +197,7 @@ export default function Hero({
                 font-weight: bold;
                 padding: 1rem 5rem;
                 align-self: flex-start;
+                white-space: pre;
               `}
               data-cy="cta-link"
             >
@@ -211,7 +219,7 @@ export default function Hero({
             {image}
           </div>
         )}
-      </div>
+      </HeroContentWrapper>
 
       {backgroundImage && (
         <div

--- a/src/components/hero.js
+++ b/src/components/hero.js
@@ -90,7 +90,7 @@ const HeroContentWrapper = styled.div`
     padding: 0 ${layout.pageMargin};
   }
 `
-const HeroTitle = styled.h1`
+export const HeroTitle = styled.h1`
   @media screen and (max-width: ${breakpoints["sm"]}) {
     font-size: 2.875rem;
   }

--- a/src/components/inpage-nav.js
+++ b/src/components/inpage-nav.js
@@ -91,11 +91,12 @@ const InpageNav = ({ shortname, items }) => {
               <a
                 href="#top"
                 css={`
-                  padding-right: 1rem;
-                  @media screen and (max-width: ${breakpoints["sm"]}) {
-                    padding-right: 0;
+                  padding-right: 0;
+                  font-size: 1.25rem;
+                  @media screen and (min-width: ${breakpoints["sm"]}) {
+                    padding-right: 1rem;
+                    font-size: 2rem;
                   }
-                  font-size: 2rem;
                   color: ${colors[POSITIVE].text};
                 `}
                 data-cy={`top-inpage-link`}

--- a/src/components/inpage-nav.js
+++ b/src/components/inpage-nav.js
@@ -57,7 +57,8 @@ const InpageNav = ({ shortname, items }) => {
             margin: 0 -6rem;
             padding: 0 6rem;
             @media screen and (max-width: ${breakpoints["sm"]}) {
-              padding: 0 2.5rem;
+              margin: 0 -2rem;
+              padding: 0 2rem;
             }
             display: flex;
             justify-content: space-between;
@@ -70,12 +71,16 @@ const InpageNav = ({ shortname, items }) => {
           <ul
             css={`
               display: flex;
-              flex-direction: row;
+              flex-direction: column;
               justify-content: flex-start;
-              align-items: center;
+              align-items: flex-start;
               margin: 0;
               padding: 0.25rem 0;
               list-style: none;
+              @media screen and (min-width: ${breakpoints["sm"]}) {
+                flex-direction: row;
+                align-items: center;
+              }
             `}
           >
             <li

--- a/src/components/layout/content-group.js
+++ b/src/components/layout/content-group.js
@@ -1,15 +1,20 @@
 import React from "react"
 import PropTypes from "prop-types"
-
+import { breakpoints } from "../../theme"
 export default function ContentGroup({ children }) {
   return (
     <div
       css={`
         flex: 2.618;
         display: grid;
-        gap: 1.5rem;
-        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
-        padding: 2rem;
+        gap: 1rem;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+        padding: 1rem;
+        @media screen and (min-width: ${breakpoints["sm"]}) {
+          gap: 1.5rem;
+          padding: 2rem;
+          grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
+        }
       `}
     >
       {children}

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -5,7 +5,7 @@
  * See: https://www.gatsbyjs.org/docs/use-static-query/
  */
 
-import React from "react"
+import React, { useRef } from "react"
 import PropTypes from "prop-types"
 import { useStaticQuery, graphql } from "gatsby"
 import styled from "styled-components"
@@ -21,12 +21,13 @@ import Nav from "../nav"
 import Footer from "../footer"
 
 import { POSITIVE } from "../../utils/constants"
+import { useContainerDimensions } from "../../utils/use-container-dimensions"
+import { breakpoints } from "../../theme"
 
 const Container = styled.div`
   display: flex;
   min-height: 100vh;
   flex-direction: column;
-  min-width: 768px;
   main {
     flex: 1;
   }
@@ -43,10 +44,17 @@ const Layout = ({ children }) => {
       }
     }
   `)
+  const container = useRef(null)
+  const { width } = useContainerDimensions(container)
+  const isMediumDown = width <= breakpoints["sm"].slice(0, -2)
 
   return (
-    <Container id="top" data-cy="page">
-      <Header shortname={data.site.siteMetadata.shortname} mode={POSITIVE}>
+    <Container id="top" data-cy="page" ref={container}>
+      <Header
+        shortname={data.site.siteMetadata.shortname}
+        mode={POSITIVE}
+        isMediumDown={isMediumDown}
+      >
         <Nav mode={POSITIVE} />
       </Header>
 

--- a/src/components/layout/page-body.js
+++ b/src/components/layout/page-body.js
@@ -1,22 +1,20 @@
 import React from "react"
+import styled from "styled-components"
 import PropTypes from "prop-types"
 
-import { layout } from "../../theme"
+import { layout, breakpoints } from "../../theme"
 
+const PageBodyStyles = styled.div`
+  width: 100%;
+  max-width: ${layout.maxWidth};
+  margin: 0 auto;
+  padding: 0 ${layout.smallPageMargin};
+  @media screen and (min-width: ${breakpoints["sm"]}) {
+    padding: 0 ${layout.pageMargin};
+  }
+`
 export default function PageBody({ children, id }) {
-  return (
-    <div
-      css={`
-        width: 100%;
-        max-width: ${layout.maxWidth};
-        margin: 0 auto;
-        padding: 0 ${layout.pageMargin};
-      `}
-      data-cy={`main-${id}`}
-    >
-      {children}
-    </div>
-  )
+  return <PageBodyStyles data-cy={`main-${id}`}>{children}</PageBodyStyles>
 }
 
 PageBody.propTypes = {

--- a/src/components/layout/section-header.js
+++ b/src/components/layout/section-header.js
@@ -1,6 +1,6 @@
 import React from "react"
 import PropTypes from "prop-types"
-
+import { breakpoints } from "../../theme"
 export default function SectionHeader({
   tagline,
   headline,
@@ -12,8 +12,11 @@ export default function SectionHeader({
   return (
     <div
       css={`
-        grid-column: 1 / span ${spanWidth};
+        grid-column: 1 / -1;
         align-self: end;
+        @media screen and (min-width: ${breakpoints["sm"]}) {
+          grid-column: 1 / span ${spanWidth};
+        }
       `}
       data-cy={`${id}-section-header`}
     >

--- a/src/components/layout/section.js
+++ b/src/components/layout/section.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types"
 import styled from "styled-components"
 
 import { POSITIVE, NEGATIVE } from "../../utils/constants"
-import { colors } from "../../theme"
+import { colors, breakpoints } from "../../theme"
 
 const Container = styled.section`
   display: grid;
@@ -53,8 +53,7 @@ Section.propTypes = {
 }
 
 export const SectionContent = styled.div`
-  grid-column: ${({ columns = [1, 12] }) =>
-    `${columns[0]} / span ${columns[1]}`};
+  grid-column: 1 / -1;
   background-color: ${({ withBackground, mode }) =>
     withBackground ? colors[mode].background : null};
   max-width: 100%;
@@ -65,6 +64,10 @@ export const SectionContent = styled.div`
   > *,
   h3 {
     color: ${props => colors[props.mode].text};
+  }
+  @media screen and (min-width: ${breakpoints["sm"]}) {
+    grid-column: ${({ columns = [1, 12] }) =>
+      `${columns[0]} / span ${columns[1]}`};
   }
 `
 

--- a/src/components/layout/section.js
+++ b/src/components/layout/section.js
@@ -12,9 +12,14 @@ const Container = styled.section`
   row-gap: 2rem;
   position: relative;
 
-  margin: ${props => (props.mode === POSITIVE ? `0 -6rem` : 0)};
-  padding: ${props => (props.mode === POSITIVE ? `6rem` : 0)};
-  margin-bottom: ${props => (props.isSpaced ? `6rem` : `6rem`)};
+  margin: ${props => (props.mode === POSITIVE ? `0 -2rem` : 0)};
+  padding: ${props => (props.mode === POSITIVE ? `2rem` : 0)};
+  margin-bottom: ${props => (props.isSpaced ? `2rem` : `2rem`)};
+  @media screen and (min-width: ${breakpoints["sm"]}) {
+    margin: ${props => (props.mode === POSITIVE ? `0 -6rem` : 0)};
+    padding: ${props => (props.mode === POSITIVE ? `6rem` : 0)};
+    margin-bottom: ${props => (props.isSpaced ? `6rem` : `6rem`)};
+  }
 
   background-color: ${props =>
     props.mode === POSITIVE ? colors[POSITIVE].background : `none`};

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -27,8 +27,14 @@ const GlobalMenu = styled.ul`
 const ListLink = ({ to, children, mode }) => (
   <li
     css={`
-      margin: 0 1rem 0 0;
+      margin: 0;
       text-transform: uppercase;
+      @media screen and (min-width: ${breakpoints["sm"]}) {
+        margin-left: 0.5rem;
+      }
+      @media screen and (min-width: ${breakpoints["md"]}) {
+        margin-left: 1rem;
+      }
     `}
   >
     <Link

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -1,10 +1,29 @@
 import React from "react"
+import styled from "styled-components"
 import PropTypes from "prop-types"
 import { Link } from "gatsby"
 
-import { colors } from "../theme"
+import { colors, breakpoints } from "../theme"
 import { POSITIVE, NEGATIVE } from "../utils/constants"
 
+const GlobalMenu = styled.ul`
+  display: flex;
+  flex: 1;
+  flex-flow: column nowrap;
+  justify-content: flex-start;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin-left: 1rem;
+  list-style: none;
+  @media screen and (min-width: ${breakpoints["sm"]}) {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+    margin: 0;
+    list-style: none;
+    flex-flow: row nowrap;
+  }
+`
 const ListLink = ({ to, children, mode }) => (
   <li
     css={`
@@ -48,44 +67,30 @@ ListLink.propTypes = {
   mode: PropTypes.oneOf([POSITIVE, NEGATIVE]),
 }
 
-const Nav = ({ mode }) => {
+const NavList = ({ mode }) => {
   return (
-    <nav
-      css={`
-        z-index: 100;
-      `}
-    >
-      <ul
-        css={`
-          display: flex;
-          flex-direction: row;
-          justify-content: flex-end;
-          margin: 0;
-          list-style: none;
-        `}
-      >
-        <ListLink to="/explore/campaigns" mode={mode}>
-          Explore
-        </ListLink>
-        <ListLink to="/glossary" mode={mode}>
-          Glossary
-        </ListLink>
-        <ListLink to="/about" mode={mode}>
-          About
-        </ListLink>
-        <ListLink to="/faq" mode={mode}>
-          FAQS
-        </ListLink>
-        <ListLink to="/contact" mode={mode}>
-          Contact
-        </ListLink>
-      </ul>
-    </nav>
+    <GlobalMenu>
+      <ListLink to="/explore/campaigns" mode={mode}>
+        Explore
+      </ListLink>
+      <ListLink to="/glossary" mode={mode}>
+        Glossary
+      </ListLink>
+      <ListLink to="/about" mode={mode}>
+        About
+      </ListLink>
+      <ListLink to="/faq" mode={mode}>
+        FAQS
+      </ListLink>
+      <ListLink to="/contact" mode={mode}>
+        Contact
+      </ListLink>
+    </GlobalMenu>
   )
 }
 
-export default Nav
+export default NavList
 
-Nav.propTypes = {
+NavList.propTypes = {
   mode: PropTypes.string.isRequired,
 }

--- a/src/components/sticky-banner.js
+++ b/src/components/sticky-banner.js
@@ -1,7 +1,12 @@
 import React, { useEffect, useState } from "react"
 import PropTypes from "prop-types"
 
-const StickyBanner = ({ children, offsetCalculator }) => {
+const StickyBanner = ({
+  children,
+  offsetCalculator,
+  isMediumDown,
+  navRevealed,
+}) => {
   const scrollDown = "scroll-down"
   const scrollUp = "scroll-up"
   const [scrollDirection, setScrollDirection] = useState(null)
@@ -54,13 +59,13 @@ const StickyBanner = ({ children, offsetCalculator }) => {
     <div
       ref={node}
       css={`
-        position: sticky;
+        position: ${isMediumDown && navRevealed ? "fixed" : "sticky"};
         top: 0;
         left: 0;
         right: 0;
         z-index: 3;
         transition: top 0.2s;
-        top: ${offset};
+        top: ${!navRevealed && offset};
       `}
     >
       {children}
@@ -72,6 +77,8 @@ StickyBanner.propTypes = {
   children: PropTypes.element,
   hideAfter: PropTypes.number,
   offsetCalculator: PropTypes.func,
+  isMediumDown: PropTypes.bool,
+  navRevealed: PropTypes.bool,
 }
 
 export default StickyBanner

--- a/src/components/typeahead-box.js
+++ b/src/components/typeahead-box.js
@@ -111,7 +111,10 @@ export function TypeAhead() {
           align-items: center;
           cursor: pointer;
           width: 100%;
-          min-width: 24rem;
+          min-width: 80vw;
+          @media screen and (min-width: 800px) {
+            min-width: 24rem;
+          }
         `}
       >
         <input

--- a/src/icons/close-icon.js
+++ b/src/icons/close-icon.js
@@ -1,11 +1,11 @@
 import React from "react"
 import PropTypes from "prop-types"
-
-const CloseIcon = ({ color = "#FFF" }) => (
+import { sizes } from "./utils"
+const CloseIcon = ({ color = "#FFF", size = "text" }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="12px"
-    height="12px"
+    width={sizes[size].width}
+    height={sizes[size].height}
     viewBox="0 0 16 16"
   >
     <polygon
@@ -17,6 +17,7 @@ const CloseIcon = ({ color = "#FFF" }) => (
 
 CloseIcon.propTypes = {
   color: PropTypes.string,
+  size: PropTypes.string,
 }
 
 export default CloseIcon

--- a/src/icons/hamburger.js
+++ b/src/icons/hamburger.js
@@ -1,0 +1,28 @@
+import React from "react"
+import PropTypes from "prop-types"
+import { sizes } from "./utils"
+
+// Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2023 Fonticons, Inc.
+
+const HamburgerIcon = ({ color = "#FFF", size = "large" }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={sizes[size].width}
+    height={sizes[size].height}
+    viewBox="0 0 16 16"
+    fill="currentColor"
+  >
+    <path
+      fill={color}
+      d="M432 256c0 17.7-14.3 32-32 32L48 288c-17.7 0-32-14.3-32-32s14.3-32 32-32l352 0c17.7 0 32 14.3 32 32z"
+    />
+    <path d="M1,9h14V7H1V9z M1,14h14v-2H1V14z M1,2v2h14V2H1z"></path>
+  </svg>
+)
+
+HamburgerIcon.propTypes = {
+  color: PropTypes.string,
+  size: PropTypes.string,
+}
+
+export default HamburgerIcon

--- a/src/icons/index.js
+++ b/src/icons/index.js
@@ -9,6 +9,7 @@ import TrashIcon from "./trash-icon"
 import FilterIcon from "./filter-icon"
 import ExternalLinkIcon from "./external-link-icon"
 import InformationIcon from "./information-icon"
+import HamburgerIcon from "./hamburger"
 
 import CampaignIcon from "./campaign-icon"
 import InstrumentIcon from "./instrument-icon"
@@ -31,6 +32,7 @@ export {
   FilterIcon,
   ExternalLinkIcon,
   InformationIcon,
+  HamburgerIcon,
 }
 
 export { CampaignIcon, InstrumentIcon, PlatformIcon, CaseiLogoIcon }

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -75,7 +75,7 @@ const About = ({ data }) => {
             <section
               css={`
                 display: grid;
-                grid-template-columns: 1fr 1fr 1fr;
+                grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
                 gap: 3rem;
               `}
               data-cy="about-inventory-objectives"
@@ -137,7 +137,7 @@ const About = ({ data }) => {
               <section
                 css={`
                   display: grid;
-                  grid-template-columns: 1fr 1fr;
+                  grid-template-columns: repeat(auto-fill, minmax(24rem, 1fr));
                   gap: 3rem;
                 `}
                 data-cy={`about-${aboutSection.id}-text`}

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -11,7 +11,7 @@ import Layout, {
 import SEO from "../components/seo"
 import ExternalLink from "../components/external-link"
 import { ArrowIcon } from "../icons"
-import { colors } from "../theme"
+import { colors, breakpoints } from "../theme"
 import { ALPHABET, POSITIVE, NEGATIVE } from "../utils/constants"
 
 export default function Glossary({ data }) {
@@ -215,8 +215,12 @@ export default function Glossary({ data }) {
             return (
               <div
                 css={`
-                  margin: 0 -6rem;
-                  padding: 0rem 6rem;
+                  margin: 0 -2rem;
+                  padding: 0rem 2rem;
+                  @media screen and (min-width: ${breakpoints["sm"]}) {
+                    margin: 0 -6rem;
+                    padding: 0rem 6rem;
+                  }
                   display: grid;
                   grid-template-columns: repeat(12, 1fr);
                   column-gap: 1rem;

--- a/src/templates/campaign/__tests__/__snapshots__/focus-section.test.js.snap
+++ b/src/templates/campaign/__tests__/__snapshots__/focus-section.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Focus Section displays content 1`] = `
 <section
-  className="section__Container-sc-1oozlr5-0 bIfvkW"
+  className="section__Container-sc-1oozlr5-0 fOmBFm"
   data-cy="focus-section"
   mode="darkTheme"
 >
@@ -111,7 +111,7 @@ exports[`Focus Section displays content 1`] = `
         className="focus-section__FocusContent-sc-tyy683-0 hhthVO"
       >
         <div
-          className="chip___StyledDiv-sc-4ga8fx-0 fAohBv"
+          className="chip___StyledDiv-sc-4ga8fx-0 cQuORu"
           data-cy="focus-phenomena-chip"
         >
           <small
@@ -121,7 +121,7 @@ exports[`Focus Section displays content 1`] = `
           </small>
         </div>
         <div
-          className="chip___StyledDiv-sc-4ga8fx-0 fAohBv"
+          className="chip___StyledDiv-sc-4ga8fx-0 cQuORu"
           data-cy="focus-phenomena-chip"
         >
           <small
@@ -145,7 +145,7 @@ exports[`Focus Section displays content 1`] = `
         className="focus-section__FocusContent-sc-tyy683-0 hhthVO"
       >
         <div
-          className="chip___StyledDiv-sc-4ga8fx-0 fAohBv"
+          className="chip___StyledDiv-sc-4ga8fx-0 cQuORu"
           data-cy="focus-mission-chip"
         >
           <small
@@ -155,7 +155,7 @@ exports[`Focus Section displays content 1`] = `
           </small>
         </div>
         <div
-          className="chip___StyledDiv-sc-4ga8fx-0 fAohBv"
+          className="chip___StyledDiv-sc-4ga8fx-0 cQuORu"
           data-cy="focus-mission-chip"
         >
           <small

--- a/src/templates/campaign/__tests__/__snapshots__/focus-section.test.js.snap
+++ b/src/templates/campaign/__tests__/__snapshots__/focus-section.test.js.snap
@@ -11,7 +11,7 @@ exports[`Focus Section displays content 1`] = `
     id="focus"
   />
   <div
-    className="section-header___StyledDiv-sc-1i4pe2i-0 SXaMi"
+    className="section-header___StyledDiv-sc-1i4pe2i-0 cVNCrb"
     data-cy="focus-section-header"
   >
     <a
@@ -23,7 +23,7 @@ exports[`Focus Section displays content 1`] = `
     </a>
   </div>
   <div
-    className="section__SectionContent-sc-1oozlr5-2 focus-section___StyledSectionContent-sc-tyy683-1 ivTKjv hFoHvE"
+    className="section__SectionContent-sc-1oozlr5-2 focus-section___StyledSectionContent-sc-tyy683-1 fHLdbu hFoHvE"
     mode="darkTheme"
   >
     <div
@@ -82,7 +82,7 @@ exports[`Focus Section displays content 1`] = `
         className="focus-section__FocusContent-sc-tyy683-0 hhthVO"
       >
         <div
-          className="button__Clickable-sc-1yw7vig-0 button___StyledClickable-sc-1yw7vig-2 fRqvWm kUpNvF"
+          className="button__Clickable-sc-1yw7vig-0 button___StyledClickable-sc-1yw7vig-2 fRqvWm dHTFWE"
         >
           <a
             data-cy="geophysical-concept-link"

--- a/src/templates/campaign/__tests__/__snapshots__/platform-section.test.js.snap
+++ b/src/templates/campaign/__tests__/__snapshots__/platform-section.test.js.snap
@@ -11,7 +11,7 @@ exports[`Platform Section displays content 1`] = `
     id="platform"
   />
   <div
-    className="section-header___StyledDiv-sc-1i4pe2i-0 SXaMi"
+    className="section-header___StyledDiv-sc-1i4pe2i-0 cVNCrb"
     data-cy="platform-section-header"
   >
     <a
@@ -23,7 +23,7 @@ exports[`Platform Section displays content 1`] = `
     </a>
   </div>
   <div
-    className="section__SectionContent-sc-1oozlr5-2 ivTKjv"
+    className="section__SectionContent-sc-1oozlr5-2 fHLdbu"
     mode="darkTheme"
   >
     <div
@@ -34,13 +34,13 @@ exports[`Platform Section displays content 1`] = `
         data-cy="carousel-list-text-control"
       >
         <button
-          className="button__Clickable-sc-1yw7vig-0 button___StyledClickable-sc-1yw7vig-2 fRqvWm jVedgi"
+          className="button__Clickable-sc-1yw7vig-0 button___StyledClickable-sc-1yw7vig-2 fRqvWm cCPXgL"
           onClick={[Function]}
         >
           J-31
         </button>
         <button
-          className="button__Clickable-sc-1yw7vig-0 button___StyledClickable-sc-1yw7vig-2 fRqvWm kUpNvF"
+          className="button__Clickable-sc-1yw7vig-0 button___StyledClickable-sc-1yw7vig-2 fRqvWm dHTFWE"
           onClick={[Function]}
         >
           Aerosonde

--- a/src/templates/campaign/__tests__/__snapshots__/platform-section.test.js.snap
+++ b/src/templates/campaign/__tests__/__snapshots__/platform-section.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Platform Section displays content 1`] = `
 <section
-  className="section__Container-sc-1oozlr5-0 bIfvkW"
+  className="section__Container-sc-1oozlr5-0 fOmBFm"
   data-cy="platform-section"
   mode="darkTheme"
 >

--- a/src/templates/campaign/__tests__/__snapshots__/program-info-section.test.js.snap
+++ b/src/templates/campaign/__tests__/__snapshots__/program-info-section.test.js.snap
@@ -11,7 +11,7 @@ exports[`Program Info Section renders logo when present in props 1`] = `
     id="program-info"
   />
   <div
-    className="section-header___StyledDiv-sc-1i4pe2i-0 SXaMi"
+    className="section-header___StyledDiv-sc-1i4pe2i-0 cVNCrb"
     data-cy="program-info-section-header"
   >
     <a
@@ -23,14 +23,14 @@ exports[`Program Info Section renders logo when present in props 1`] = `
     </a>
   </div>
   <div
-    className="section__SectionContent-sc-1oozlr5-2 eZkTzL"
+    className="section__SectionContent-sc-1oozlr5-2 dwmZKy"
     mode="darkTheme"
   >
     <div
-      className="program-info-section___StyledDiv-sc-celi18-0 kubiqB"
+      className="program-info-section___StyledDiv-sc-celi18-0 gqRZlk"
     >
       <div
-        className="program-info-section___StyledDiv2-sc-celi18-1 eiVFAq"
+        className="program-info-section___StyledDiv2-sc-celi18-1 jmfHdz"
       >
         <div
           className="program-info-section___StyledDiv3-sc-celi18-2 cbYsnX"
@@ -287,7 +287,7 @@ exports[`Program Info Section renders placeholder when no logo is available 1`] 
     id="program-info"
   />
   <div
-    className="section-header___StyledDiv-sc-1i4pe2i-0 SXaMi"
+    className="section-header___StyledDiv-sc-1i4pe2i-0 cVNCrb"
     data-cy="program-info-section-header"
   >
     <a
@@ -299,14 +299,14 @@ exports[`Program Info Section renders placeholder when no logo is available 1`] 
     </a>
   </div>
   <div
-    className="section__SectionContent-sc-1oozlr5-2 eZkTzL"
+    className="section__SectionContent-sc-1oozlr5-2 dwmZKy"
     mode="darkTheme"
   >
     <div
-      className="program-info-section___StyledDiv-sc-celi18-0 kubiqB"
+      className="program-info-section___StyledDiv-sc-celi18-0 gqRZlk"
     >
       <div
-        className="program-info-section___StyledDiv2-sc-celi18-1 eiVFAq"
+        className="program-info-section___StyledDiv2-sc-celi18-1 jmfHdz"
       >
         <svg
           height="120"

--- a/src/templates/campaign/__tests__/__snapshots__/program-info-section.test.js.snap
+++ b/src/templates/campaign/__tests__/__snapshots__/program-info-section.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Program Info Section renders logo when present in props 1`] = `
 <section
-  className="section__Container-sc-1oozlr5-0 bIfvkW"
+  className="section__Container-sc-1oozlr5-0 fOmBFm"
   data-cy="program-info-section"
   mode="darkTheme"
 >
@@ -148,7 +148,7 @@ exports[`Program Info Section renders logo when present in props 1`] = `
         </div>
       </div>
       <div
-        className="content-group___StyledDiv-sc-gouaoh-0 gWModr"
+        className="content-group___StyledDiv-sc-gouaoh-0 jbLbih"
       >
         <div
           data-cy="program-info-content"
@@ -278,7 +278,7 @@ exports[`Program Info Section renders logo when present in props 1`] = `
 
 exports[`Program Info Section renders placeholder when no logo is available 1`] = `
 <section
-  className="section__Container-sc-1oozlr5-0 bIfvkW"
+  className="section__Container-sc-1oozlr5-0 fOmBFm"
   data-cy="program-info-section"
   mode="darkTheme"
 >
@@ -328,7 +328,7 @@ exports[`Program Info Section renders placeholder when no logo is available 1`] 
         </svg>
       </div>
       <div
-        className="content-group___StyledDiv-sc-gouaoh-0 gWModr"
+        className="content-group___StyledDiv-sc-gouaoh-0 jbLbih"
       >
         <div
           data-cy="program-info-content"

--- a/src/templates/campaign/hero.js
+++ b/src/templates/campaign/hero.js
@@ -5,7 +5,7 @@ import styled from "styled-components"
 import { GatsbyImage } from "gatsby-plugin-image"
 import turfBbox from "@turf/bbox"
 
-import { HeroStats } from "../../components/hero"
+import { HeroStats, HeroTitle } from "../../components/hero"
 import Map from "../../components/map"
 import BboxLayer from "../../components/map/bbox-layer"
 import GeoJsonSource from "../../components/map/geojson-source"
@@ -126,7 +126,9 @@ const CampaignHero = ({
             ) : (
               <CampaignIcon />
             )}
-            <h1 data-cy="campaign-hero-header">{longname || shortname}</h1>
+            <HeroTitle data-cy="campaign-hero-header">
+              {longname || shortname}
+            </HeroTitle>
             <p>{focusListing}</p>
           </div>
           <HeroStats

--- a/src/templates/campaign/hero.js
+++ b/src/templates/campaign/hero.js
@@ -10,7 +10,7 @@ import Map from "../../components/map"
 import BboxLayer from "../../components/map/bbox-layer"
 import GeoJsonSource from "../../components/map/geojson-source"
 import { ArrowIcon, CampaignIcon } from "../../icons"
-import { colors, layout } from "../../theme"
+import { colors, layout, breakpoints } from "../../theme"
 import { useContainerDimensions } from "../../utils/use-container-dimensions"
 import { NEGATIVE } from "../../utils/constants"
 
@@ -69,6 +69,10 @@ const CampaignHero = ({
            {
             grid-area: 1 / 2 / 1 / 2;
             display: flex;
+            flex-direction: column;
+            @media screen and (min-width: ${breakpoints["sm"]}) {
+              flex-direction: row;
+            }
             padding: 0 0 7rem 0;
             z-index: 1;
           }
@@ -78,7 +82,10 @@ const CampaignHero = ({
           css={`
              {
               flex: 2;
-              padding: ${`3rem ${layout.pageMargin}`};
+              padding: 3rem ${layout.smallPageMargin};
+              @media screen and (min-width: ${breakpoints["sm"]}) {
+                padding: 3rem ${layout.pageMargin};
+              }
             }
           `}
         >
@@ -137,7 +144,9 @@ const CampaignHero = ({
         <div
           css={`
              {
-              flex: 1;
+              @media screen and (max-width: ${breakpoints["sm"]}) {
+                flex: 1;
+              }
             }
           `}
         ></div>

--- a/src/templates/campaign/program-info-section.js
+++ b/src/templates/campaign/program-info-section.js
@@ -11,6 +11,7 @@ import {
   ContentGroup,
 } from "../../components/layout"
 import { CampaignIcon } from "../../icons"
+import { breakpoints } from "../../theme"
 
 const ProgramInfoSection = ({
   id,
@@ -56,15 +57,23 @@ const ProgramInfoSection = ({
         <div
           css={`
             display: flex;
+            flex-direction: column;
+            @media screen and (min-width: ${breakpoints["sm"]}) {
+              flex-direction: row;
+            }
           `}
         >
           <div
             css={`
               flex: 0.618;
               display: flex;
+              flex-direction: column;
               justify-content: center;
               align-items: center;
               padding: 1rem;
+              @media screen and (min-width: ${breakpoints["sm"]}) {
+                flex-direction: row;
+              }
             `}
           >
             {logoFullWidth && logoFullWidth.gatsbyImg ? (

--- a/src/templates/instrument/__tests__/__snapshots__/overview-section.test.js.snap
+++ b/src/templates/instrument/__tests__/__snapshots__/overview-section.test.js.snap
@@ -27,7 +27,7 @@ exports[`Overview Section displays content 1`] = `
     }
   >
     <div
-      className="section-header___StyledDiv-sc-1i4pe2i-0 SXaMi"
+      className="section-header___StyledDiv-sc-1i4pe2i-0 cVNCrb"
       data-cy="unique-id-section-header"
     >
       <a
@@ -40,7 +40,7 @@ exports[`Overview Section displays content 1`] = `
     </div>
   </span>
   <div
-    className="section__SectionContent-sc-1oozlr5-2 KrgTv"
+    className="section__SectionContent-sc-1oozlr5-2 lbiqbu"
     mode="lightTheme"
   >
     <h3>
@@ -134,7 +134,7 @@ exports[`Overview Section displays content 1`] = `
         </dt>
         <dd>
           <a
-            className="external-link___StyledA-sc-3ezy1s-0 cAMswR"
+            className="external-link___StyledA-sc-3ezy1s-0 imQDdv"
             data-cy="calibration-doi-link"
             href="http://dx.doi.org/10.5067/calibration"
             rel="noopener noreferrer"
@@ -181,7 +181,7 @@ exports[`Overview Section displays content 1`] = `
               className="overview-section___StyledLi3-sc-1oemh85-9 kDzWeD"
             >
               <a
-                className="external-link___StyledA-sc-3ezy1s-0 cAMswR"
+                className="external-link___StyledA-sc-3ezy1s-0 imQDdv"
                 data-cy="online-information-link"
                 href="http://www.example.com"
                 rel="noopener noreferrer"
@@ -219,7 +219,7 @@ exports[`Overview Section displays content 1`] = `
     </section>
   </div>
   <div
-    className="section__SectionContent-sc-1oozlr5-2 jZFvXE"
+    className="section__SectionContent-sc-1oozlr5-2 cpDwKd"
     mode="lightTheme"
   >
     <ul
@@ -287,7 +287,7 @@ exports[`Overview Section displays content 1`] = `
           DOI:
            
           <a
-            className="external-link___StyledA-sc-3ezy1s-0 iQSFnp"
+            className="external-link___StyledA-sc-3ezy1s-0 cuaQiH"
             data-cy="instrument-doi-link"
             href="http://dx.doi.org/10.5067/instrument"
             rel="noopener noreferrer"
@@ -350,7 +350,7 @@ exports[`Overview Section displays content 1`] = `
             className="list-link___StyledLi-sc-xxtxki-0 iqaryc"
           >
             <a
-              className="external-link___StyledA-sc-3ezy1s-0 cAMswR"
+              className="external-link___StyledA-sc-3ezy1s-0 imQDdv"
               data-cy="test-link"
               href="http://www.example.com"
               rel="noopener noreferrer"
@@ -386,7 +386,7 @@ exports[`Overview Section displays content 1`] = `
             className="list-link___StyledLi-sc-xxtxki-0 iqaryc"
           >
             <a
-              className="external-link___StyledA-sc-3ezy1s-0 cAMswR"
+              className="external-link___StyledA-sc-3ezy1s-0 imQDdv"
               data-cy="test2-link"
               href="http://www.example.com"
               rel="noopener noreferrer"

--- a/src/templates/instrument/__tests__/__snapshots__/overview-section.test.js.snap
+++ b/src/templates/instrument/__tests__/__snapshots__/overview-section.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Overview Section displays content 1`] = `
 <section
-  className="section__Container-sc-1oozlr5-0 iMnAlB"
+  className="section__Container-sc-1oozlr5-0 iwtLeQ"
   data-cy="unique-id-section"
   mode="lightTheme"
 >
@@ -161,7 +161,9 @@ exports[`Overview Section displays content 1`] = `
                 fill="#15418c"
               />
             </svg>
-            <span>
+            <span
+              className="external-link___StyledSpan-sc-3ezy1s-1 gYHqzm"
+            >
               http://dx.doi.org/10.5067/calibration
             </span>
           </a>
@@ -208,7 +210,9 @@ exports[`Overview Section displays content 1`] = `
                     fill="#15418c"
                   />
                 </svg>
-                <span>
+                <span
+                  className="external-link___StyledSpan-sc-3ezy1s-1 gYHqzm"
+                >
                   http://www.example.com
                 </span>
               </a>
@@ -314,7 +318,9 @@ exports[`Overview Section displays content 1`] = `
                 fill="#aac9ff"
               />
             </svg>
-            <span>
+            <span
+              className="external-link___StyledSpan-sc-3ezy1s-1 gYHqzm"
+            >
               http://dx.doi.org/10.5067/instrument
             </span>
           </a>
@@ -377,7 +383,9 @@ exports[`Overview Section displays content 1`] = `
                   fill="#15418c"
                 />
               </svg>
-              <span>
+              <span
+                className="external-link___StyledSpan-sc-3ezy1s-1 gYHqzm"
+              >
                 test
               </span>
             </a>
@@ -413,7 +421,9 @@ exports[`Overview Section displays content 1`] = `
                   fill="#15418c"
                 />
               </svg>
-              <span>
+              <span
+                className="external-link___StyledSpan-sc-3ezy1s-1 gYHqzm"
+              >
                 test2
               </span>
             </a>


### PR DESCRIPTION
Implements mobile header, footer, and overall page and component level responsiveness.

<img src="https://github.com/user-attachments/assets/dee2f3b2-2018-4236-b890-ed9a6cd37be2" width="150" /><img src="https://github.com/user-attachments/assets/8365838a-7c5e-44ef-a238-0e722d372ab9" width="150" />


I'm attempting to move most new styles into styled components for consistency, rather than Gatsby's `css` utility. This is mainly just to keep styles in a consistent place, rather than locating on the component jsx level, but I'm open to revision.