### PR TITLE
Redirect /explore to /explore/campaigns

### DIFF
--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -76,7 +76,7 @@ ListLink.propTypes = {
 const NavList = ({ mode }) => {
   return (
     <GlobalMenu>
-      <ListLink to="/explore/campaigns" mode={mode}>
+      <ListLink to="/explore" mode={mode}>
         Explore
       </ListLink>
       <ListLink to="/glossary" mode={mode}>

--- a/src/pages/explore/index.js
+++ b/src/pages/explore/index.js
@@ -1,0 +1,8 @@
+import { navigate } from "gatsby"
+import { useEffect } from "react"
+
+export default function ExploreRedirect() {
+  useEffect(() => navigate("/explore/campaigns"))
+
+  return false
+}


### PR DESCRIPTION
Possible solution to the issue that avoids the Explore menu item from being active 