### PR TITLE
Improve GlobeView flight tracks color selection

### DIFF
--- a/src/components/map/globe-map.js
+++ b/src/components/map/globe-map.js
@@ -139,7 +139,11 @@ export function GlobeMap({
     lineWidthMinPixels: 0.5,
     getLineWidth: 1,
     getLineColor: f =>
-      getLineColorAsRGB(movingPlatforms.indexOf(f.properties.platform_name)),
+      getLineColorAsRGB(
+        movingPlatforms
+          .filter((i, index) => movingPlatforms.indexOf(i) === index) // remove duplicates
+          .indexOf(f.properties.platform_name)
+      ),
   })
 
   const staticLocations = new IconLayer({

--- a/src/components/timeline/__tests__/map-legend.test.js
+++ b/src/components/timeline/__tests__/map-legend.test.js
@@ -19,6 +19,14 @@ describe("MapLegend", () => {
       <MapLegend
         platforms={[
           { name: "Falcon", type: "Jet" },
+          { name: "G-H", type: "Jet" },
+          { name: "ER-2", type: "Jet" },
+          { name: "DC-8", type: "Jet" },
+          { name: "Learjet", type: "Jet" },
+          { name: "OtterTwin", type: "Jet" },
+          { name: "Laserjet", type: "Jet" },
+          { name: "B-200", type: "Jet" },
+          { name: "ABC", type: "Jet" },
           { name: "Field Site", type: "static" },
           { name: "Field Site", type: "static" },
         ]}
@@ -28,14 +36,18 @@ describe("MapLegend", () => {
       />
     )
     const instance = element.root
-    expect(instance.findAllByType("input").length).toBe(2)
+    expect(instance.findAllByType("input").length).toBe(10)
     const b1 = instance.findAllByType("input")[0]
     expect(
       instance.findAllByType("input").every(i => !i.props.checked)
     ).toBeTruthy()
     act(() => b1.props.onClick())
     expect(fn).toHaveBeenCalledTimes(1)
-    expect(instance.findByType(LineIcon).props.size).toBe("text")
+    expect(instance.findAllByType(LineIcon)[0].props.size).toBe("text")
+    expect(instance.findAllByType(LineIcon)[0].props.color).toBe("#b2df8a")
+    expect(instance.findAllByType(LineIcon)[7].props.color).toBe("#e31a1c")
+    // test fallback color to the 9º moving platform
+    expect(instance.findAllByType(LineIcon)[8].props.color).toBe("#1a9b8c")
     expect(instance.findByType(FieldSiteIcon)).toBeTruthy()
   })
   it("render with one option selected", () => {

--- a/src/components/timeline/map-legend.js
+++ b/src/components/timeline/map-legend.js
@@ -86,11 +86,7 @@ export const MapLegend = ({
             key={platform.name}
             type="moving"
             name={platform.name}
-            color={
-              index <= MOVING_PLATFORMS_COLORS.length
-                ? MOVING_PLATFORMS_COLORS[index]
-                : FALLBACK_COLOR
-            }
+            color={MOVING_PLATFORMS_COLORS[index] || FALLBACK_COLOR}
             checked={selectedPlatforms.includes(platform.name)}
             disabled={
               (selectedPlatforms.length === 1 &&

--- a/src/utils/__tests__/platform-colors.test.js
+++ b/src/utils/__tests__/platform-colors.test.js
@@ -56,12 +56,19 @@ describe("getStaticIcons", () => {
 })
 
 describe("getLineColorAsRGB", () => {
+  const platforms = ["DC-8", "ER-2", "GH", "Learjet"]
   it("returns the color in RGB format", () => {
-    const platforms = ["DC-8", "ER-2", "GH", "Learjet"]
     expect(getLineColorAsRGB(platforms.indexOf("DC-8"))).toEqual([
       178, 223, 138,
     ])
     expect(getLineColorAsRGB(platforms.indexOf("GH"))).toEqual([253, 191, 111])
+    expect(getLineColorAsRGB(platforms.indexOf("GH"))).toEqual([253, 191, 111])
+    expect(getLineColorAsRGB(7)).toEqual([227, 26, 28])
+  })
+  it("returns the fallback color in RGB format if index is -1 or greater than 7", () => {
+    expect(getLineColorAsRGB(platforms.indexOf("ABC"))).toEqual([26, 155, 140])
+    expect(getLineColorAsRGB(8)).toEqual([26, 155, 140])
+    expect(getLineColorAsRGB(9)).toEqual([26, 155, 140])
   })
 })
 

--- a/src/utils/platform-colors.js
+++ b/src/utils/platform-colors.js
@@ -81,8 +81,8 @@ export const flightPathColors = platforms =>
 const hex2rgb = hex => hex.match(/[0-9a-f]{2}/g).map(x => parseInt(x, 16))
 
 export const getLineColorAsRGB = index => {
-  if (index === -1) return hex2rgb(FALLBACK_COLOR)
   const color = MOVING_PLATFORMS_COLORS[index]
+  if (color === undefined) return hex2rgb(FALLBACK_COLOR)
   // converts from HEX to RGB
   return hex2rgb(color)
 }


### PR DESCRIPTION
The globe view was failing to render the flight tracks of the INTEX-NA campaign as it has 8 moving platforms.

It also avoids some errors in the map and in the legend when we have 8 or more moving platforms.

@LanesGood if you want to test with the INTEX-NA campaign, you can copy the geojson file from http://admg-inventory-staging.s3-website-us-east-1.amazonaws.com/casei/flight-tracks/INTEX-NA.geojson