### PR TITLE
Use campaign repositories for Program Info section DAAC

### DIFF
--- a/src/templates/campaign/index.js
+++ b/src/templates/campaign/index.js
@@ -120,6 +120,7 @@ const CampaignTemplate = ({ data: { campaign }, path }) => {
           .join(", "),
         partnerWebsite: campaign.partnerWebsite,
         websites: campaign.websites,
+        repositories: campaign.repositories,
       },
     },
     // "other-resources": {

--- a/src/templates/campaign/program-info-section.js
+++ b/src/templates/campaign/program-info-section.js
@@ -23,10 +23,8 @@ const ProgramInfoSection = ({
   dataManager,
   partnerOrgListing,
   websites,
+  repositories,
 }) => {
-  const repositoryWebsite = websites?.find(
-    x => x.type.name === "Repository Website"
-  )
   const publicationLink = websites?.find(
     x => x.type.name === "Overview Publication"
   )
@@ -39,8 +37,8 @@ const ProgramInfoSection = ({
     { label: "Data Manager / Technical Contact", info: dataManager },
     {
       label: "NASA Data Repository",
-      info: repositoryWebsite?.url,
-      link: repositoryWebsite?.url,
+      info: repositories[0]?.shortname,
+      link: repositories[0]?.url,
     },
     { label: "Partner Organizations", info: partnerOrgListing },
     {
@@ -158,6 +156,12 @@ ProgramInfoSection.propTypes = {
       }),
     })
   ),
+  repositories: PropTypes.arrayOf(
+    PropTypes.shape({
+      shortname: PropTypes.string.isRequired,
+      url: PropTypes.string.isRequired,
+    }).isRequired
+  ).isRequired,
 }
 
 export default ProgramInfoSection

--- a/src/templates/campaign/program-info-section.js
+++ b/src/templates/campaign/program-info-section.js
@@ -37,8 +37,8 @@ const ProgramInfoSection = ({
     { label: "Data Manager / Technical Contact", info: dataManager },
     {
       label: "NASA Data Repository",
-      info: repositories[0]?.shortname,
-      link: repositories[0]?.url,
+      info: repositories && repositories[0]?.shortname,
+      link: repositories && repositories[0]?.url,
     },
     { label: "Partner Organizations", info: partnerOrgListing },
     {


### PR DESCRIPTION
Replaces the campaign page "Program Info" section's "Campaign Repository" link with the first item in the Repositories list. 

To confirm if this affects any campaigns where there may be multiple repositories

cc @smwingo 

Fixes https://github.com/NASA-IMPACT/ADMG-project/issues/1213#issuecomment-2704899868