### PR TITLE
Fix CampaignHero width

### DIFF
--- a/src/templates/campaign/hero.js
+++ b/src/templates/campaign/hero.js
@@ -56,7 +56,7 @@ const CampaignHero = ({
          {
           display: grid;
           grid-template-columns: ${`1fr minmax(auto, ${layout.maxWidth}) 1fr`};
-          width: 100vw;
+          max-width: 100%;
           min-height: 35rem;
           align-content: center;
         }


### PR DESCRIPTION
There is a horizontal scroll bar on the Campaigns' page, caused by the width of the hero map (see image below or staging/production website). This PR fixes it.

<img width="503" alt="image" src="https://github.com/user-attachments/assets/d6a5971a-08d1-4855-8617-d78a5f6bc22b" />
