### PR TITLE
Add suport to more moving and static platforms

### DIFF
--- a/src/components/deployments/__tests__/map-legend.test.js
+++ b/src/components/deployments/__tests__/map-legend.test.js
@@ -27,6 +27,11 @@ describe("MapLegend", () => {
           { name: "Laserjet", type: "Jet" },
           { name: "B-200", type: "Jet" },
           { name: "ABC", type: "Jet" },
+          { name: "OtterTwin2", type: "Jet" },
+          { name: "Learjet2", type: "Jet" },
+          { name: "B-300", type: "Jet" },
+          { name: "ABCD", type: "Jet" },
+          { name: "Plane", type: "Jet" },
           { name: "Field Site", type: "static" },
           { name: "Field Site", type: "static" },
         ]}
@@ -36,7 +41,7 @@ describe("MapLegend", () => {
       />
     )
     const instance = element.root
-    expect(instance.findAllByType("input").length).toBe(10)
+    expect(instance.findAllByType("input").length).toBe(15)
     const b1 = instance.findAllByType("input")[0]
     expect(
       instance.findAllByType("input").every(i => !i.props.checked)
@@ -45,9 +50,9 @@ describe("MapLegend", () => {
     expect(fn).toHaveBeenCalledTimes(1)
     expect(instance.findAllByType(LineIcon)[0].props.size).toBe("text")
     expect(instance.findAllByType(LineIcon)[0].props.color).toBe("#b2df8a")
-    expect(instance.findAllByType(LineIcon)[7].props.color).toBe("#e31a1c")
-    // test fallback color to the 9º moving platform
-    expect(instance.findAllByType(LineIcon)[8].props.color).toBe("#1a9b8c")
+    expect(instance.findAllByType(LineIcon)[12].props.color).toBe("#e31a1c")
+    // test fallback color to the 12º moving platform
+    expect(instance.findAllByType(LineIcon)[13].props.color).toBe("#1a9b8c")
     expect(instance.findByType(FieldSiteIcon)).toBeTruthy()
   })
   it("render with one option selected", () => {

--- a/src/components/deployments/__tests__/map-legend.test.js
+++ b/src/components/deployments/__tests__/map-legend.test.js
@@ -7,6 +7,7 @@ import {
   BalloonIcon,
   FieldSiteIcon,
 } from "../../../icons/static-platform-icons"
+import { FALLBACK_COLOR } from "../../../utils/platform-colors"
 
 jest.mock("react-tooltip", () => ({
   Tooltip: () => <div>Mocked tooltip</div>,
@@ -50,9 +51,13 @@ describe("MapLegend", () => {
     expect(fn).toHaveBeenCalledTimes(1)
     expect(instance.findAllByType(LineIcon)[0].props.size).toBe("text")
     expect(instance.findAllByType(LineIcon)[0].props.color).toBe("#b2df8a")
-    expect(instance.findAllByType(LineIcon)[12].props.color).toBe("#e31a1c")
+    expect(instance.findAllByType(LineIcon)[12].props.color).toBe(
+      FALLBACK_COLOR
+    )
     // test fallback color to the 12º moving platform
-    expect(instance.findAllByType(LineIcon)[13].props.color).toBe("#1a9b8c")
+    expect(instance.findAllByType(LineIcon)[13].props.color).toBe(
+      FALLBACK_COLOR
+    )
     expect(instance.findByType(FieldSiteIcon)).toBeTruthy()
   })
   it("render with one option selected", () => {

--- a/src/utils/__tests__/platform-colors.test.js
+++ b/src/utils/__tests__/platform-colors.test.js
@@ -51,6 +51,10 @@ describe("getStaticIcons", () => {
       STATIC_PLATFORMS[7].mapIcon,
       STATIC_PLATFORMS[8].name,
       STATIC_PLATFORMS[8].mapIcon,
+      STATIC_PLATFORMS[9].name,
+      STATIC_PLATFORMS[9].mapIcon,
+      STATIC_PLATFORMS[10].name,
+      STATIC_PLATFORMS[10].mapIcon,
       "BalloonIcon",
     ]
     expect(getStaticIcons()).toEqual(result)
@@ -65,12 +69,12 @@ describe("getLineColorAsRGB", () => {
     ])
     expect(getLineColorAsRGB(platforms.indexOf("GH"))).toEqual([253, 191, 111])
     expect(getLineColorAsRGB(platforms.indexOf("GH"))).toEqual([253, 191, 111])
-    expect(getLineColorAsRGB(7)).toEqual([227, 26, 28])
+    expect(getLineColorAsRGB(12)).toEqual([227, 26, 28])
   })
-  it("returns the fallback color in RGB format if index is -1 or greater than 7", () => {
+  it("returns the fallback color in RGB format if index is -1 or greater than 12", () => {
     expect(getLineColorAsRGB(platforms.indexOf("ABC"))).toEqual([26, 155, 140])
-    expect(getLineColorAsRGB(8)).toEqual([26, 155, 140])
-    expect(getLineColorAsRGB(9)).toEqual([26, 155, 140])
+    expect(getLineColorAsRGB(13)).toEqual([26, 155, 140])
+    expect(getLineColorAsRGB(14)).toEqual([26, 155, 140])
   })
 })
 

--- a/src/utils/__tests__/platform-colors.test.js
+++ b/src/utils/__tests__/platform-colors.test.js
@@ -69,7 +69,7 @@ describe("getLineColorAsRGB", () => {
     ])
     expect(getLineColorAsRGB(platforms.indexOf("GH"))).toEqual([253, 191, 111])
     expect(getLineColorAsRGB(platforms.indexOf("GH"))).toEqual([253, 191, 111])
-    expect(getLineColorAsRGB(12)).toEqual([227, 26, 28])
+    expect(getLineColorAsRGB(12)).toEqual([26, 155, 140])
   })
   it("returns the fallback color in RGB format if index is -1 or greater than 12", () => {
     expect(getLineColorAsRGB(platforms.indexOf("ABC"))).toEqual([26, 155, 140])

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -44,4 +44,5 @@ export const MOVING_PLATFORMS = [
   "USV",
   "Drifting Buoy",
   "Ships/Boats",
+  "Saildrone",
 ]

--- a/src/utils/platform-colors.js
+++ b/src/utils/platform-colors.js
@@ -100,7 +100,10 @@ export const STATIC_PLATFORMS = [
 ]
 
 export const flightPathColors = platforms =>
-  platforms.map((i, index) => [i, MOVING_PLATFORMS_COLORS[index]])
+  platforms.map((i, index) => [
+    i,
+    MOVING_PLATFORMS_COLORS[index] || FALLBACK_COLOR,
+  ])
 
 const hex2rgb = hex => hex.match(/[0-9a-f]{2}/g).map(x => parseInt(x, 16))
 

--- a/src/utils/platform-colors.js
+++ b/src/utils/platform-colors.js
@@ -25,7 +25,6 @@ export const MOVING_PLATFORMS_COLORS = [
   "#6a3d9a",
   "#ffff99",
   "#b15928",
-  "#e31a1c",
 ]
 
 export const FALLBACK_COLOR = "#1a9b8c"

--- a/src/utils/platform-colors.js
+++ b/src/utils/platform-colors.js
@@ -20,11 +20,11 @@ export const MOVING_PLATFORMS_COLORS = [
   "#a6cee3",
   "#1f78b4",
   "#fb9a99",
-  "#673AB7",
-  "#F2B705",
-  "#69544F",
-  "#AB47BC",
-  "#B9A7A2",
+  "#e31a1c",
+  "#cab2d6",
+  "#6a3d9a",
+  "#ffff99",
+  "#b15928",
   "#e31a1c",
 ]
 

--- a/src/utils/platform-colors.js
+++ b/src/utils/platform-colors.js
@@ -20,6 +20,11 @@ export const MOVING_PLATFORMS_COLORS = [
   "#a6cee3",
   "#1f78b4",
   "#fb9a99",
+  "#673AB7",
+  "#F2B705",
+  "#69544F",
+  "#AB47BC",
+  "#B9A7A2",
   "#e31a1c",
 ]
 
@@ -63,8 +68,20 @@ export const STATIC_PLATFORMS = [
     mapIcon: "PermanentWaterIcon",
   },
   {
+    name: "Neutrally Buoyant Float",
+    color: "#F2B705",
+    icon: <PermanentWaterSiteIcon />,
+    mapIcon: "PermanentWaterIcon",
+  },
+  {
     name: "Moored Buoy",
     color: "#8C2D04",
+    icon: <MooredBuoyIcon />,
+    mapIcon: "MooredBuoyIcon",
+  },
+  {
+    name: "ARGO",
+    color: "#FFF7AE",
     icon: <MooredBuoyIcon />,
     mapIcon: "MooredBuoyIcon",
   },


### PR DESCRIPTION
There is a [new campaing](http://admg-inventory-staging.s3-website-us-east-1.amazonaws.com/casei/campaign/SPURS/) that is failing as it exceeds the number of Moving Platforms we added before. It was also missing some icons for two new Static Platforms. I've added 4 new colours and re-used 2 icons.

@LanesGood Do you think you would have time to check the colours and icons and propose new ones if you think it needs something different?

You can use this geojson to test it locally: http://admg-inventory-staging.s3-website-us-east-1.amazonaws.com/casei/flight-tracks/SPURS.geojson