### PR TITLE
Update background style. Update header background and styles.

### DIFF
--- a/src/components/__tests__/__snapshots__/chip.test.js.snap
+++ b/src/components/__tests__/__snapshots__/chip.test.js.snap
@@ -11,14 +11,14 @@ exports[`Chip renders with action 1`] = `
     Weather
   </small>
   <button
-    className="button__Clickable-sc-1c81fec-0 button___StyledClickable2-sc-1c81fec-1 dsHorc gpewNA"
+    className="button__Clickable-sc-1c81fec-0 button__ClickableIcon-sc-1c81fec-1 dImKvl goJtrU"
     data-cy="remove-filter"
     onClick={[Function]}
     type="button"
   >
     <span
       aria-label="remove-filter-icon"
-      className="button___StyledSpan-sc-1c81fec-3 gThnOP"
+      className="button___StyledSpan-sc-1c81fec-2 hqlpTe"
       role="img"
     >
       <svg

--- a/src/components/__tests__/__snapshots__/header.test.js.snap
+++ b/src/components/__tests__/__snapshots__/header.test.js.snap
@@ -2,18 +2,18 @@
 
 exports[`Header renders correctly 1`] = `
 <div
-  className="sticky-banner___StyledDiv-sc-884fdm-0 iGcwwZ"
+  className="sticky-banner___StyledDiv-sc-884fdm-0 hjlHFE"
 >
   <header
-    className="header__PageHeaderSelf-sc-1x62ed1-0 jQmQSm"
+    className="header__PageHeaderSelf-sc-1x62ed1-0 gGPVBR"
     id="main-header"
     mode="lightTheme"
   >
     <div
-      className="header__PageHeaderInner-sc-1x62ed1-1 fEcpjo"
+      className="header__PageHeaderInner-sc-1x62ed1-1 iKmYnc"
     >
       <div
-        className="header__PageHeadline-sc-1x62ed1-2 brFoSG"
+        className="header__PageHeadline-sc-1x62ed1-2 ctVnvm"
       >
         <a
           aria-label="Visit nasa.gov (opens in a new window)"
@@ -258,7 +258,7 @@ exports[`Header renders correctly 1`] = `
           className="header__VerticalDivider-sc-1x62ed1-5 drJENr"
         />
         <a
-          className="header__SiteImageLink-sc-1x62ed1-6 iySDMU"
+          className="header__SiteImageLink-sc-1x62ed1-6 gQJlSj"
           href="/"
         >
           <svg
@@ -278,9 +278,9 @@ exports[`Header renders correctly 1`] = `
               strokeWidth="1"
             >
               <g
-                fill="#262a31"
+                fill="#ffffff"
                 fillRule="nonzero"
-                stroke="#262a31"
+                stroke="#ffffff"
                 strokeWidth="0.5"
                 transform="translate(-132.000000, -29.000000)"
               >
@@ -291,7 +291,7 @@ exports[`Header renders correctly 1`] = `
             </g>
           </svg>
           <div
-            className="header__SiteName-sc-1x62ed1-7 gjlzvR"
+            className="header__SiteName-sc-1x62ed1-7 kjpyCA"
             mode="lightTheme"
           >
             Shortname from props
@@ -299,36 +299,45 @@ exports[`Header renders correctly 1`] = `
         </a>
       </div>
       <div
-        className="header__PageNavToggleWrapper-sc-1x62ed1-8 dlYNcK"
+        className="header__PageNavToggleWrapper-sc-1x62ed1-8 bQnkpq"
       >
         <button
-          className="button__Clickable-sc-1c81fec-0 button___StyledClickable-sc-1c81fec-2 dsHorc iHwhbN"
+          className="button__Clickable-sc-1c81fec-0 button__ClickableIcon-sc-1c81fec-1 dImKvl goJtrU"
+          data-cy="Nav Menu Toggle"
           onClick={[Function]}
+          type="button"
         >
-          <svg
-            fill="currentColor"
-            height="16"
-            viewBox="0 0 16 16"
-            width="16"
-            xmlns="http://www.w3.org/2000/svg"
+          <span
+            aria-label="Nav Menu Toggle-icon"
+            className="button___StyledSpan-sc-1c81fec-2 hqlpTe"
+            role="img"
           >
-            <path
-              d="M432 256c0 17.7-14.3 32-32 32L48 288c-17.7 0-32-14.3-32-32s14.3-32 32-32l352 0c17.7 0 32 14.3 32 32z"
-              fill="#262a31"
-            />
-            <path
-              d="M1,9h14V7H1V9z M1,14h14v-2H1V14z M1,2v2h14V2H1z"
-            />
-          </svg>
+            <svg
+              fill="currentColor"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M432 256c0 17.7-14.3 32-32 32L48 288c-17.7 0-32-14.3-32-32s14.3-32 32-32l352 0c17.7 0 32 14.3 32 32z"
+                fill="#FFF"
+              />
+              <path
+                d="M1,9h14V7H1V9z M1,14h14v-2H1V14z M1,2v2h14V2H1z"
+                fill="#FFF"
+              />
+            </svg>
+          </span>
         </button>
       </div>
       <nav
-        className="header__PageNavWrapper-sc-1x62ed1-3 fumqDI"
+        className="header__PageNavWrapper-sc-1x62ed1-3 UfsJl"
         mode="lightTheme"
         role="navigation"
       >
         <ul
-          className="nav__PrimeMenu-sc-xno5zg-3 droVXw"
+          className="nav__PrimeMenu-sc-xno5zg-3 hifMkU"
           mode="lightTheme"
         >
           <li>
@@ -364,13 +373,13 @@ exports[`Header renders correctly 1`] = `
                   width="16"
                 />
                 <polygon
-                  fill="#262a31"
+                  fill="#ffffff"
                   points="12.586,4.586 8,9.172 3.414,4.586 2,6 8,12 14,6"
                 />
               </svg>
             </a>
             <section
-              className="nav__PrimeMenuBlock-sc-xno5zg-1 vHuXd"
+              className="nav__PrimeMenuBlock-sc-xno5zg-1 flObaJ"
             >
               <h6
                 className="nav__PrimeMenuBlockTitle-sc-xno5zg-2 jjxXKR"

--- a/src/components/__tests__/__snapshots__/header.test.js.snap
+++ b/src/components/__tests__/__snapshots__/header.test.js.snap
@@ -332,7 +332,7 @@ exports[`Header renders correctly 1`] = `
         </button>
       </div>
       <nav
-        className="header__PageNavWrapper-sc-1x62ed1-3 UfsJl"
+        className="header__PageNavWrapper-sc-1x62ed1-3 wYZiN"
         mode="lightTheme"
         role="navigation"
       >

--- a/src/components/__tests__/__snapshots__/hero.test.js.snap
+++ b/src/components/__tests__/__snapshots__/hero.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Header renders correctly 1`] = `
 <section
-  className="hero__Container-sc-eyerl9-0 bKuvRr"
+  className="hero__Container-sc-eyerl9-0 fYxBTf"
   data-cy="test-hero"
 >
   <div
@@ -89,7 +89,7 @@ exports[`Header renders correctly 1`] = `
 
 exports[`Header renders with adjust ratios 1`] = `
 <section
-  className="hero__Container-sc-eyerl9-0 bKuvRr"
+  className="hero__Container-sc-eyerl9-0 fYxBTf"
   data-cy="undefined-hero"
 >
   <div

--- a/src/components/button.js
+++ b/src/components/button.js
@@ -6,6 +6,26 @@ import { POSITIVE, NEGATIVE } from "../utils/constants"
 import { colors } from "../theme"
 
 const Clickable = styled.button`
+  display: inline-flex;
+  flex-flow: row nowrap;
+  justify-content: center;
+  align-items: center;
+  user-select: none;
+  color: ${({ overrideMode }) => overrideMode && colors[overrideMode].text};
+  text-align: center;
+  vertical-align: middle;
+  padding: ${({ iconOnly }) => (iconOnly ? "0.5rem" : "0.25rem 0.75rem")};
+  background: none;
+  text-shadow: none;
+  border: ${({ noBorder, overrideMode }) =>
+    overrideMode &&
+    (noBorder ? "none" : `1px solid ${colors[overrideMode].text}`)};
+  cursor: pointer;
+  background-color: ${({ isSecondary, mode, overrideMode }) =>
+    overrideMode &&
+    (isSecondary ? colors[mode].background : colors[overrideMode].background)};
+  font-weight: bold;
+  white-space: nowrap;
   &:hover {
     opacity: 0.64;
   }
@@ -25,36 +45,17 @@ const Button = React.forwardRef(
       : mode === NEGATIVE
       ? POSITIVE
       : NEGATIVE
-
+    console.log(overrideMode)
     return (
       <Clickable
         as={as}
         ref={ref}
         onClick={action}
-        css={`
-           {
-            display: inline-flex;
-            flex-flow: row nowrap;
-            justify-content: center;
-            align-items: center;
-            user-select: none;
-            color: ${colors[overrideMode].text};
-            text-align: center;
-            vertical-align: middle;
-            padding: ${iconOnly ? "0.5rem" : "0.25rem 0.75rem"};
-            background: none;
-            text-shadow: none;
-            border: ${noBorder
-              ? "none"
-              : `1px solid ${colors[overrideMode].text}`};
-            cursor: pointer;
-            background-color: ${isSecondary
-              ? colors[mode].background
-              : colors[overrideMode].background};
-            font-weight: bold;
-            white-space: nowrap;
-          }
-        `}
+        mode={mode}
+        overrideMode={overrideMode}
+        isSecondary={isSecondary}
+        iconOnly={iconOnly}
+        noBorder={noBorder}
       >
         {children}
       </Clickable>
@@ -77,20 +78,18 @@ Button.displayName = "Button"
 
 export default Button
 
+const ClickableIcon = styled(Clickable)`
+  background: none;
+  border: none;
+  flex-grow: 0;
+  padding: 0.5rem;
+  cursor: pointer;
+  color: ${colors[NEGATIVE].text};
+  vertical-align: middle;
+`
+
 export const IconButton = ({ id, icon, action, type }) => (
-  <Clickable
-    type={type || "button"}
-    onClick={action}
-    css={`
-      background: none;
-      border: none;
-      flex-grow: 0;
-      cursor: pointer;
-      color: ${colors[NEGATIVE].text};
-      vertical-align: middle;
-    `}
-    data-cy={id}
-  >
+  <ClickableIcon type={type || "button"} onClick={action} data-cy={id}>
     <span
       role="img"
       aria-label={`${id}-icon`}
@@ -101,7 +100,7 @@ export const IconButton = ({ id, icon, action, type }) => (
     >
       {icon}
     </span>
-  </Clickable>
+  </ClickableIcon>
 )
 
 IconButton.propTypes = {

--- a/src/components/global.css
+++ b/src/components/global.css
@@ -2,11 +2,7 @@ body {
   margin: 0;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background: radial-gradient(
-    100vh circle at top center,
-    #345e9d -25%,
-    #172a45 25%
-  );
+  background: radial-gradient(100vh circle at top center, #234165, #0c1520);
   background-attachment: fixed;
 }
 

--- a/src/components/global.css
+++ b/src/components/global.css
@@ -2,7 +2,12 @@ body {
   margin: 0;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background: #294060;
+  background: radial-gradient(
+    100vh circle at top center,
+    #345e9d -25%,
+    #172a45 25%
+  );
+  background-attachment: fixed;
 }
 
 .bottom-right {
@@ -18,9 +23,9 @@ body {
   display: inline-block;
   box-sizing: border-box;
   animation: rotation 1s linear infinite;
-  }
+}
 
-  @keyframes rotation {
+@keyframes rotation {
   0% {
     transform: rotate(0deg);
   }

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useState, useEffect } from "react"
 import PropTypes from "prop-types"
 import styled, { css, keyframes, createGlobalStyle } from "styled-components"
 import { Link } from "gatsby"
@@ -7,9 +7,10 @@ import { colors, layout, breakpoints } from "../theme"
 import { CaseiLogoIcon, CloseIcon, HamburgerIcon } from "../icons"
 import { NEGATIVE, POSITIVE } from "../utils/constants"
 import StickyBanner from "./sticky-banner"
-import Button from "./button"
+import { IconButton } from "./button"
 import NasaLogoIcon from "../icons/nasa-logo"
 import NavList from "./nav"
+import UnscrollableBody from "./unscrollable-body"
 
 const reveal = keyframes`
 0% {
@@ -20,11 +21,18 @@ const reveal = keyframes`
 }
 `
 const PageHeaderSelf = styled.header`
-  z-index: 3;
-  background-color: ${({ mode }) => mode && colors[mode].background};
+  z-index: 3000;
+  background: ${({ scrolledUp }) =>
+    scrolledUp
+      ? "radial-gradient(100vh circle at top center, hsl(216, 50%, 41%) -25%,hsl(215, 50%, 18%) 25%)"
+      : "transparent"};
+  color: ${({ mode }) => mode && colors[mode].background};
   box-shadow: rgba(68, 63, 63, 0.08) 0px -1px 1px 0px,
     rgba(68, 63, 63, 0.08) 0px 2px 6px 0px;
   animation: ${reveal} 0.32s ease 0s 1;
+  @media screen and (min-width: ${breakpoints["sm"]}) {
+    backdrop-filter: blur(10px);
+  }
 `
 
 const PageHeaderInner = styled.div`
@@ -39,7 +47,7 @@ const PageHeaderInner = styled.div`
   align-items: center;
 
   position: relative;
-  z-index: 30;
+  z-index: 3000;
   /* Animation */
   animation: ${reveal} 0.32s ease 0s 1;
   &::before {
@@ -53,7 +61,7 @@ const PageHeaderInner = styled.div`
     background: linear-gradient(
       0deg,
       rgba(255, 255, 255, 0) 75%,
-      rgba(255, 255, 255, 1) 100%
+      hsl(215, 50%, 18%) 100%
     );
     @media screen and (min-width: ${breakpoints["sm"]}) {
       display: none;
@@ -62,7 +70,7 @@ const PageHeaderInner = styled.div`
 `
 const PageHeadline = styled.div`
   margin: 0;
-  z-index: 100;
+  z-index: 1000;
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -76,13 +84,18 @@ const PageNavWrapper = styled.div`
   left: 0;
   right: 0;
   height: 100%;
-  z-index: 20;
+  z-index: 900;
   display: flex;
   flex-flow: column nowrap;
   padding: 5rem 2rem 1rem;
   overflow: auto;
   pointer-events: auto;
-  background-color: ${({ mode }) => mode && colors[mode].background};
+  background: radial-gradient(
+    100vh circle at top center,
+    hsl(216, 50%, 41%) -25%,
+    hsl(215, 50%, 18%) 25%
+  );
+  color: ${({ mode }) => mode && colors[mode].background};
   transform: translate(0, -100%);
   margin: 0;
   transition: all 0.4s ease-in-out 0s;
@@ -103,6 +116,7 @@ const PageNavWrapper = styled.div`
     transform: translate(0, 0);
     justify-content: space-between;
     box-shadow: none;
+    background: none;
   }
 `
 const BrandImageLink = styled.a`
@@ -131,6 +145,7 @@ const SiteImageLink = styled(Link)`
   grid-template-columns: max-content auto;
   column-gap: 0.5rem;
   align-items: center;
+  color: ${({ mode }) => mode && colors[mode].background};
   @media screen and (min-width: ${breakpoints["sm"]}) {
     column-gap: 1rem;
   }
@@ -147,14 +162,14 @@ const SiteImageLink = styled(Link)`
 `
 const SiteName = styled.div`
   font-size: 1.25rem;
-  color: ${({ mode }) => mode && colors[mode].text};
+  color: ${({ mode }) => mode && colors[mode].background};
   @media screen and (min-width: ${breakpoints["sm"]}) {
     font-size: 1.5rem;
   }
 `
 const PageNavToggleWrapper = styled.div`
   position: relative;
-  z-index: 50;
+  z-index: 5000;
   display: flex;
   flex-flow: row nowrap;
   justify-content: flex-end;
@@ -162,7 +177,6 @@ const PageNavToggleWrapper = styled.div`
     display: none;
   }
 `
-const PageNavToggle = styled(Button)``
 
 const PageNavGlobalStyle = createGlobalStyle`
   body {
@@ -176,10 +190,29 @@ const PageNavGlobalStyle = createGlobalStyle`
 
 const Header = ({ shortname, mode }) => {
   const [navRevealed, setNavRevealed] = useState(false)
+  const [scrolledUp, setScrolledUp] = useState(false)
+
+  useEffect(() => {
+    let lastScroll = window.scrollY
+    const onScroll = () => {
+      const currentScroll = window.scrollY
+      if (currentScroll <= 0) {
+        setScrolledUp(false)
+      } else if (currentScroll < lastScroll) {
+        setScrolledUp(true)
+      } else if (currentScroll > lastScroll) {
+        setScrolledUp(false)
+      }
+      lastScroll = currentScroll
+    }
+    window.addEventListener("scroll", onScroll)
+    return () => window.removeEventListener("scroll", onScroll)
+  }, [])
 
   return (
     <StickyBanner navRevealed={navRevealed}>
-      <PageHeaderSelf id="main-header" mode={mode}>
+      <PageHeaderSelf id="main-header" mode={mode} scrolledUp={scrolledUp}>
+        {navRevealed && <UnscrollableBody />}
         <PageHeaderInner>
           <PageHeadline>
             <BrandImageLink
@@ -194,24 +227,24 @@ const Header = ({ shortname, mode }) => {
             <VerticalDivider />
 
             <SiteImageLink to="/">
-              <CaseiLogoIcon color={colors[mode].text} />
+              <CaseiLogoIcon color={colors[mode].background} />
               <SiteName mode={mode}>{shortname}</SiteName>
             </SiteImageLink>
           </PageHeadline>
           <PageNavGlobalStyle isActive={navRevealed} />
           <PageNavToggleWrapper>
-            <PageNavToggle
+            <IconButton
               title="Reveal/hide menu"
+              id="Nav Menu Toggle"
               action={() => setNavRevealed(v => !v)}
-              iconOnly
-              noBorder
-            >
-              {navRevealed ? (
-                <CloseIcon size="text" color={colors[mode].text} />
-              ) : (
-                <HamburgerIcon size="text" color={colors[mode].text} />
-              )}
-            </PageNavToggle>
+              icon={
+                navRevealed ? (
+                  <CloseIcon size="text" />
+                ) : (
+                  <HamburgerIcon size="text" />
+                )
+              }
+            />
           </PageNavToggleWrapper>
           <PageNavWrapper
             mode={mode}

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -24,7 +24,7 @@ const PageHeaderSelf = styled.header`
   z-index: 3000;
   background: ${({ scrolledUp }) =>
     scrolledUp
-      ? "radial-gradient(100vh circle at top center, hsl(216, 50%, 41%) -25%,hsl(215, 50%, 18%) 25%)"
+      ? "radial-gradient(100vh circle at top center, #234165, #0c1520)"
       : "transparent"};
   color: ${({ mode }) => mode && colors[mode].background};
   box-shadow: rgba(68, 63, 63, 0.08) 0px -1px 1px 0px,
@@ -90,11 +90,7 @@ const PageNavWrapper = styled.div`
   padding: 5rem 2rem 1rem;
   overflow: auto;
   pointer-events: auto;
-  background: radial-gradient(
-    100vh circle at top center,
-    hsl(216, 50%, 41%) -25%,
-    hsl(215, 50%, 18%) 25%
-  );
+  background: radial-gradient(100vh circle at top center, #234165, #0c1520);
   color: ${({ mode }) => mode && colors[mode].background};
   transform: translate(0, -100%);
   margin: 0;

--- a/src/components/hero.js
+++ b/src/components/hero.js
@@ -66,7 +66,7 @@ const Container = styled.section`
   display: grid;
   grid-template-columns: 1fr minmax(auto, ${layout.maxWidth}) 1fr;
   min-height: 35rem;
-  align-content: center;
+  align-content: stretch;
   margin-bottom: 6rem;
   background: ${({ backgroundImage, ratioInPercent }) =>
     backgroundImage

--- a/src/components/inpage-nav.js
+++ b/src/components/inpage-nav.js
@@ -104,91 +104,85 @@ const InpageNav = ({ shortname, items }) => {
   }
 
   return (
-    <StickyBanner offsetCalculator={offsetCalculator}>
-      <div
+    <StickyBanner offsetCalculator={offsetCalculator} secondaryNav>
+      <nav
+        aria-label="inpage-scroll"
         css={`
-          z-index: 1000;
+          margin: 0 -6rem;
+          padding: 0 6rem;
+          @media screen and (max-width: ${breakpoints["sm"]}) {
+            margin: 0 -2rem;
+            padding: 0 2rem;
+          }
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          background-color: ${colors[POSITIVE].background};
+          color: ${colors[POSITIVE].text};
         `}
+        data-cy="inpage-nav"
       >
-        <nav
-          aria-label="inpage-scroll"
+        <ul
           css={`
-            margin: 0 -6rem;
-            padding: 0 6rem;
-            @media screen and (max-width: ${breakpoints["sm"]}) {
-              margin: 0 -2rem;
-              padding: 0 2rem;
-            }
             display: flex;
-            justify-content: space-between;
-            align-items: center;
-            background-color: ${colors[POSITIVE].background};
-            color: ${colors[POSITIVE].text};
+            flex-direction: column;
+            justify-content: flex-start;
+            align-items: flex-start;
+            margin: 0;
+            padding: 0.25rem 0;
+            list-style: none;
+            overflow: auto;
+            @media screen and (min-width: ${breakpoints["xs"]}) {
+              flex-direction: row;
+              align-items: center;
+            }
           `}
-          data-cy="inpage-nav"
         >
-          <ul
+          <li
             css={`
-              display: flex;
-              flex-direction: column;
-              justify-content: flex-start;
-              align-items: flex-start;
-              margin: 0;
-              padding: 0.25rem 0;
-              list-style: none;
-              overflow: auto;
-              @media screen and (min-width: ${breakpoints["xs"]}) {
-                flex-direction: row;
-                align-items: center;
-              }
+              margin: 0 1rem 0 0;
             `}
           >
-            <li
+            <a
+              href="#top"
+              onClick={e => {
+                e.preventDefault()
+                window.scrollTo({ top: 0, behavior: "smooth" })
+              }}
               css={`
-                margin: 0 1rem 0 0;
+                padding-right: 0;
+                font-size: 1.25rem;
+                @media screen and (min-width: ${breakpoints["sm"]}) {
+                  padding-right: 1rem;
+                  font-size: 2rem;
+                }
+                color: ${colors[POSITIVE].text};
               `}
+              data-cy={`top-inpage-link`}
             >
-              <a
-                href="#top"
-                onClick={e => {
-                  e.preventDefault()
-                  window.scrollTo({ top: 0, behavior: "smooth" })
-                }}
-                css={`
-                  padding-right: 0;
-                  font-size: 1.25rem;
-                  @media screen and (min-width: ${breakpoints["sm"]}) {
-                    padding-right: 1rem;
-                    font-size: 2rem;
-                  }
-                  color: ${colors[POSITIVE].text};
-                `}
-                data-cy={`top-inpage-link`}
-              >
-                {shortname}
-              </a>
-            </li>
-            {items.map(item => (
-              <InpageLink
-                key={item.id}
-                id={item.id}
-                onClick={handleLinkClick(item.id)}
-                active={activeId === item.id}
-              >
-                {item.label}
-              </InpageLink>
-            ))}
-          </ul>
-          <Button
-            action={() => {
-              window.open(FEEDBACK_FORM_URL, "_blank")
-            }}
-            mode={POSITIVE}
-          >
-            Feedback
-          </Button>
-        </nav>
-      </div>
+              {shortname}
+            </a>
+          </li>
+          {items.map(item => (
+            <InpageLink
+              key={item.id}
+              id={item.id}
+              onClick={handleLinkClick(item.id)}
+              active={activeId === item.id}
+            >
+              {item.label}
+            </InpageLink>
+          ))}
+        </ul>
+        <Button
+          action={() => {
+            window.open(FEEDBACK_FORM_URL, "_blank")
+          }}
+          mode={POSITIVE}
+        >
+          Feedback
+        </Button>
+      </nav>
     </StickyBanner>
   )
 }

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -19,7 +19,7 @@ const StyledLink = styled(Link)`
 `
 
 const PrimeMenuBlock = styled.section`
-  color: #ffffff;
+  color: ${({ mode }) => mode && colors[mode].background};
 
   @media screen and (min-width: ${breakpoints["sm"]}) {
     box-shadow: rgba(68, 63, 63, 0.08) 0px -1px 1px 0px,
@@ -58,7 +58,7 @@ const PrimeMenu = styled.ul`
   > li {
     position: relative;
     ${StyledLink} {
-      color: ${({ mode }) => mode && colors[mode].text};
+      color: ${({ mode }) => mode && colors[mode].background};
     }
     @media screen and (min-width: ${breakpoints["sm"]}) {
       margin: 0 0 0 1rem;
@@ -66,7 +66,7 @@ const PrimeMenu = styled.ul`
   }
 
   ${PrimeMenuBlockTitle} {
-    color: ${({ mode }) => mode && colors[mode].text};
+    color: ${({ mode }) => mode && colors[mode].background};
   }
   ${PrimeMenuBlock} {
     transition: all 0.16s ease 0s;
@@ -74,7 +74,7 @@ const PrimeMenu = styled.ul`
     @media screen and (min-width: ${breakpoints["sm"]}) {
       position: absolute;
       right: 0;
-      background: #ffffff;
+      background: ${({ mode }) => mode && colors[mode].text};
       visibility: hidden;
       opacity: 0;
       transform: translate(0, -0.25rem);
@@ -98,7 +98,7 @@ const PrimeMenu = styled.ul`
         position: absolute;
         left: 0;
         bottom: 100%;
-        background: #ffffff;
+        background: ${({ mode }) => mode && colors[mode].text};
         height: 0.25rem;
         width: 100%;
         display: block;
@@ -139,7 +139,7 @@ const NavList = ({ mode, onLinkClick }) => {
           Learn{" "}
           <ChevronIcon
             role="img"
-            color={colors[mode].text}
+            color={colors[mode].background}
             aria-label="chevron-icon"
           />
         </StyledLink>

--- a/src/components/sticky-banner.js
+++ b/src/components/sticky-banner.js
@@ -4,6 +4,7 @@ import PropTypes from "prop-types"
 const StickyBanner = ({
   children,
   navRevealed,
+  secondaryNav,
   offsetCalculator: childOffsetCalculator,
 }) => {
   const scrollDown = "scroll-down"
@@ -66,7 +67,7 @@ const StickyBanner = ({
         top: 0;
         left: 0;
         right: 0;
-        z-index: 3;
+        z-index: ${secondaryNav ? 5 : 10};
         transition: top 0.2s;
         top: ${!navRevealed && offset};
       `}
@@ -80,6 +81,7 @@ StickyBanner.propTypes = {
   children: PropTypes.element,
   hideAfter: PropTypes.number,
   navRevealed: PropTypes.bool,
+  secondaryNav: PropTypes.bool,
   offsetCalculator: PropTypes.func,
 }
 

--- a/src/components/unscrollable-body.js
+++ b/src/components/unscrollable-body.js
@@ -1,0 +1,15 @@
+import { useEffect } from "react"
+
+function UnscrollableBody() {
+  useEffect(() => {
+    document.body.style.overflow = "hidden"
+
+    return () => {
+      document.body.style.overflow = ""
+    }
+  }, [])
+
+  return null
+}
+
+export default UnscrollableBody

--- a/src/icons/hamburger.js
+++ b/src/icons/hamburger.js
@@ -16,7 +16,10 @@ const HamburgerIcon = ({ color = "#FFF", size = "large" }) => (
       fill={color}
       d="M432 256c0 17.7-14.3 32-32 32L48 288c-17.7 0-32-14.3-32-32s14.3-32 32-32l352 0c17.7 0 32 14.3 32 32z"
     />
-    <path d="M1,9h14V7H1V9z M1,14h14v-2H1V14z M1,2v2h14V2H1z"></path>
+    <path
+      fill={color}
+      d="M1,9h14V7H1V9z M1,14h14v-2H1V14z M1,2v2h14V2H1z"
+    ></path>
   </svg>
 )
 

--- a/src/templates/campaign/__tests__/__snapshots__/focus-section.test.js.snap
+++ b/src/templates/campaign/__tests__/__snapshots__/focus-section.test.js.snap
@@ -82,7 +82,8 @@ exports[`Focus Section displays content 1`] = `
         className="focus-section__FocusContent-sc-14x93tz-0 fMxbvH"
       >
         <div
-          className="button__Clickable-sc-1c81fec-0 button___StyledClickable-sc-1c81fec-2 dsHorc bXMmgm"
+          className="button__Clickable-sc-1c81fec-0 kWyXnx"
+          mode="darkTheme"
         >
           <a
             data-cy="geophysical-concept-link"

--- a/src/templates/campaign/__tests__/__snapshots__/platform-section.test.js.snap
+++ b/src/templates/campaign/__tests__/__snapshots__/platform-section.test.js.snap
@@ -34,13 +34,15 @@ exports[`Platform Section displays content 1`] = `
         data-cy="carousel-list-text-control"
       >
         <button
-          className="button__Clickable-sc-1c81fec-0 button___StyledClickable-sc-1c81fec-2 dsHorc kKZQgp"
+          className="button__Clickable-sc-1c81fec-0 fnOmoW"
+          mode="darkTheme"
           onClick={[Function]}
         >
           J-31
         </button>
         <button
-          className="button__Clickable-sc-1c81fec-0 button___StyledClickable-sc-1c81fec-2 dsHorc bXMmgm"
+          className="button__Clickable-sc-1c81fec-0 kWyXnx"
+          mode="darkTheme"
           onClick={[Function]}
         >
           Aerosonde


### PR DESCRIPTION
I noticed while onboarding last year that the original designs for the homepage were never implemented as designed. Unfortunately InVision is no longer available to check original designs, but we can see some screenshots in tickets #95 and #261.

The main change is a radial gradient applied to the background. This helps unify the page, which mostly follows a dark background/light text pattern. The new background is slightly darker and more saturated; this also helps emphasize imagery and provides greater contrast for the text. This PR also updates the header to use the same styles - you can see this more clearly when scrolled down on the campaign page.

@smwingo please feel free to leave design comments directly in this PR.

| Live | This PR
| --| -- |
|![Screenshot 2025-06-17 at 11 21 55 AM](https://github.com/user-attachments/assets/052405c6-197d-4337-9346-651060cb8bbc) |  ![Screenshot 2025-06-17 at 11 21 43 AM](https://github.com/user-attachments/assets/c818c9dc-8299-4a1f-a88d-2c8a7be2e553)|
|![Screenshot 2025-06-17 at 11 22 01 AM](https://github.com/user-attachments/assets/2e974937-d6e8-4cb1-8f74-9538f87d24f5) | ![Screenshot 2025-06-17 at 11 21 22 AM](https://github.com/user-attachments/assets/4392596d-ff1d-4a0a-9ff2-4b025cc11f55)|
|![Screenshot 2025-06-17 at 11 22 47 AM](https://github.com/user-attachments/assets/27515009-3701-4be4-9e85-575e5c45458e) | ![Screenshot 2025-06-17 at 11 22 54 AM](https://github.com/user-attachments/assets/b6358082-787f-470a-998a-460e1db41c31) |
|![Screenshot 2025-06-17 at 11 22 06 AM](https://github.com/user-attachments/assets/99bc81fc-b377-4935-a5c1-7db5696bc781) | ![Screenshot 2025-06-17 at 11 21 35 AM](https://github.com/user-attachments/assets/c4716c59-91fc-49f6-be76-ec3528f68dd2)|
